### PR TITLE
fix: added missing fn in ring_temp.rs

### DIFF
--- a/src/datalogger/src/drivers/ring_temperature.rs
+++ b/src/datalogger/src/drivers/ring_temperature.rs
@@ -1,5 +1,6 @@
 // use alloc::fmt::format;
 
+use crate::any_as_u8_slice;
 use crate::sensor_name_from_type_id;
 
 use super::mcp9808::*;
@@ -221,12 +222,18 @@ impl SensorDriver for RingTemperatureDriver {
         }
         Ok(())
     }
-    
+
     fn get_configuration_bytes(&self, storage: &mut [u8; rriv_board::EEPROM_SENSOR_SETTINGS_SIZE]) {
-        todo!()
+        // right now this just gets the bytes
+        // but the special settings probably should be consisted as member variables and copied back to the storage struct
+
+        let generic_settings_bytes: &[u8] = unsafe { any_as_u8_slice(&self.general_config) };
+        let special_settings_bytes: &[u8] = unsafe { any_as_u8_slice(&self.special_config) };
+
+        copy_config_into_partition(0, generic_settings_bytes, storage);
+        copy_config_into_partition(1, special_settings_bytes, storage);
     }
-    
+
     fn update_actuators(&mut self, board: &mut dyn rriv_board::SensorDriverServices) {
-        todo!()
     }
 }


### PR DESCRIPTION
Added the functions `get_configuration_bytes` and `update_actuators` in the ring_temperature.rs file