### PR TITLE
fixes

### DIFF
--- a/board/rriv_board_0_4_2/src/components/eeprom.rs
+++ b/board/rriv_board_0_4_2/src/components/eeprom.rs
@@ -4,7 +4,7 @@ use embedded_hal::prelude::{
     _embedded_hal_blocking_i2c_WriteRead,
 };
 use crate::Board;
-use rriv_board::{RRIVBoard, EEPROM_SERIAL_NUMBER_SIZE};
+use rriv_board::RRIVBoard;
 use rtt_target::rprintln;
 
 // implementation specific consts

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -509,7 +509,7 @@ impl SensorDriverServices for Board {
         match self.internal_adc.read(channel) {
             Ok(value) => return value,
             Err(error) => {
-                let mut error_string = match error {
+                let error_string = match error {
                     AdcError::NBError(_) => "Internal ADC NBError",
                     AdcError::NotConfigured => "Internal ADC Not Configured",
                     AdcError::ReadError => "Internal ADC Read Error",
@@ -942,7 +942,7 @@ impl BoardBuilder {
             let device_peripherals = pac::Peripherals::steal();
             let gpiod = device_peripherals.GPIOD.split();
 
-            let mut gpio5 = gpiod.pd2;
+            let gpio5 = gpiod.pd2;
             let mut gpio5 = gpio5.into_dynamic(&mut gpio_cr.gpiod_crl);
             gpio5.make_open_drain_output(&mut gpio_cr.gpiod_crl);
 

--- a/board/rriv_board_0_4_2/src/pin_groups/adc_internal.rs
+++ b/board/rriv_board_0_4_2/src/pin_groups/adc_internal.rs
@@ -1,4 +1,4 @@
-use stm32f1xx_hal::{gpio::*, afio::MAPR};
+use stm32f1xx_hal::gpio::*;
 use crate::pins::*;
 
 

--- a/board/rriv_board_0_4_2/src/pin_groups/mod.rs
+++ b/board/rriv_board_0_4_2/src/pin_groups/mod.rs
@@ -65,7 +65,7 @@ pub fn build(
     );
 
 
-    let mut power = PowerPins::build(pins.enable_3v, pins.enable_5v, cr);
+    let power = PowerPins::build(pins.enable_3v, pins.enable_5v, cr);
 
     // power.enable_3v.set_high();
     // delay.delay_ms(2000_u32);

--- a/board/rriv_board_0_4_2/src/pin_groups/oscillator_control.rs
+++ b/board/rriv_board_0_4_2/src/pin_groups/oscillator_control.rs
@@ -1,4 +1,4 @@
-use stm32f1xx_hal::{gpio::*, afio::MAPR};
+use stm32f1xx_hal::gpio::*;
 use crate::pins::*;
 
 pub struct OscillatorControlPins {


### PR DESCRIPTION
- fix: modified I2C addresses
- fix: include missing implementations
- fix: force release
- fix: added missing fn in ring_temp.rs
- chore(release): 1.1.2 [skip ci]
- fix: adjust setup order so that rtc clock init errors are caught by the watchdog
- chore(release): 1.1.3 [skip ci]
- chore: name as elf
- chore: Update build-binary.yaml
- chore: Update build-binary.yaml
- chore: Update semantic-release.yaml
- fix: some cargo fixes
