### PR TITLE
test release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # RRIV Firmware
-  
+
 RRIV embedded firmware, written in Rust.
- 
+
 [![chat](https://img.shields.io/badge/chat-probe--rs%3Amatrix.org-brightgreen)](https://matrix.to/#/#rriv-rust:matrix.x24.tools)
 
-## Getting Started / Development Setup
+# Getting Started / Development Setup
 
 You will need to install the Rust toolchain. The easiest way to do this is with [rustup](https://rustup.rs/).
 


### PR DESCRIPTION
- fix: modified I2C addresses
- fix: include missing implementations
- fix: force release
- fix: added missing fn in ring_temp.rs
- chore(release): 1.1.2 [skip ci]
- fix: adjust setup order so that rtc clock init errors are caught by the watchdog
- chore(release): 1.1.3 [skip ci]
- chore: name as elf
- chore: Update build-binary.yaml
- chore: Update build-binary.yaml
- chore: Update semantic-release.yaml
- fix: some cargo fixes
- chore(release): 1.1.4 [skip ci]
- fix: Update semantic-release.yaml
- chore(release): 1.1.5 [skip ci]
- fix: force release
- fix: force release
