### PR TITLE
fix: enable setting of interactive_logging

### DIFF
--- a/src/datalogger/src/datalogger/payloads.rs
+++ b/src/datalogger/src/datalogger/payloads.rs
@@ -18,7 +18,8 @@ pub struct DataloggerSettingsValues {
     pub delay_between_bursts: Option<u16>,
     pub bursts_per_measurement_cycle: Option<u8>,
     pub mode: Option<u8>,
-    pub enable_telemetry: Option<bool>
+    pub enable_telemetry: Option<bool>,
+    pub interactive_logging: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -33,7 +34,8 @@ pub struct DataloggerSetPayload {
     pub bursts_per_cycle: Option<u8>,
     pub start_up_delay: Option<u16>,
     pub mode: Option<Value>,
-    pub enable_telemetry: Option<bool>
+    pub enable_telemetry: Option<bool>,
+    pub interactive_logging: Option<bool>,
     // pub user_note: Option<Value>, // not implemented for now
     // pub user_value: Option<i16>
 }
@@ -100,6 +102,10 @@ impl DataloggerSetPayload {
 
         if let Some(enable_telemetry) = self.enable_telemetry {
             datalogger_settings_values.enable_telemetry = Some(enable_telemetry);
+        }
+
+        if let Some(interactive_logging) = self.interactive_logging {
+            datalogger_settings_values.interactive_logging = Some(interactive_logging);
         }
 
         datalogger_settings_values

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -12,6 +12,7 @@ use rriv_board::{
     RRIVBoard, EEPROM_DATALOGGER_SETTINGS_SIZE, EEPROM_SENSOR_SETTINGS_SIZE,
     EEPROM_TOTAL_SENSOR_SLOTS,
 };
+use serde::de::value;
 use util::any_as_u8_slice;
 extern crate alloc;
 use crate::datalogger::bytes;
@@ -1071,9 +1072,13 @@ impl DataLogger {
                     .release(self.telemeter.get_requested_gpios());
             }
         }
-
+        let int_logging = values.interactive_logging;
         let new_settings = self.settings.with_values(values);
         self.settings = new_settings;
+        
+        if let Some(interactive_logging) = int_logging {
+            self.interactive_logging = interactive_logging;
+        }
         if let Some(mode) = mode {
             self.set_mode(board, mode);
         }
@@ -1093,7 +1098,8 @@ impl DataLogger {
            "delay_between_bursts" : self.settings.delay_between_bursts,
            "bursts_per_measurement_cycle" : self.settings.bursts_per_measurement_cycle,
            "mode" : datalogger::modes::mode_text(&self.mode),
-           "enable_telemetry" : self.settings.toggles.enable_telemetry()
+           "enable_telemetry" : self.settings.toggles.enable_telemetry(),
+           "interactive_logging": self.interactive_logging
         })
     }
 


### PR DESCRIPTION
we can now set the interactive_logging option using `rrivctl set datalogger interactive_logging true` command