### PR TITLE
fix: run build automation with ref

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -51,6 +51,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.release.outputs.new-release-git-tag }}
   
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
Add checkout step to use new release git tag