### PR TITLE
fix: measured parameter count for 0 channels

### DIFF
--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -262,7 +262,11 @@ impl SensorDriver for RingMuxTemperatureDriver {
     getters!();
 
     fn get_measured_parameter_count(&mut self) -> usize {
-        self.special_config.sensors * 2 * self.special_config.channels
+        let mut channels_used = 1;
+        if self.special_config.channels > 0 {
+            channels_used = self.special_config.channels;
+        }
+        self.special_config.sensors * 2 * channels_used
     }
 
     fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {


### PR DESCRIPTION
This fix is for the number of measured parameters when the driver is used without the multiplexer (`channels = 0`)