### PR TITLE
fix uid

### DIFF
--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -1370,6 +1370,11 @@ impl DataLogger {
             assignments[7].clone_from_slice(id);
             assignments[8].clone_from_slice(id);
         }
-        responses::device_get(board, serial_number, uid, assignments);
+        match responses::device_get(board, serial_number, uid, assignments){
+            Ok(_) => {},
+            Err(_) => {
+                responses::send_command_response_error(board, "could not build response", "");
+            },
+        }
     }
 }

--- a/src/datalogger/src/protocol/responses.rs
+++ b/src/datalogger/src/protocol/responses.rs
@@ -49,7 +49,7 @@ pub fn calibration_point_list(board: &mut impl RRIVBoard, pairs: &Option<Box<[Ca
     board.usb_serial_send(format_args!("]}}\n"));
 }
 
-pub fn device_get(board: &mut impl RRIVBoard, mut serial_number: [u8;5], uid : [u8;12], mut gpio_assignments: [[u8;6];9]){
+pub fn device_get(board: &mut impl RRIVBoard, mut serial_number: [u8;5], uid : [u8;12], mut gpio_assignments: [[u8;6];9]) -> Result<(),()>{
     defmt::println!("{:?}", serial_number);
     let serial_number = util::str_from_utf8(&mut serial_number).unwrap_or_default();
     defmt::println!("uid {}", uid);
@@ -80,6 +80,7 @@ pub fn device_get(board: &mut impl RRIVBoard, mut serial_number: [u8;5], uid : [
             }
             Err(e) => {
                 defmt::println!("format error {}", defmt::Debug2Format(&e));
+                return Err(());
             },
         }
 
@@ -100,4 +101,5 @@ pub fn device_get(board: &mut impl RRIVBoard, mut serial_number: [u8;5], uid : [
         }
     });
     send_json(board, json);
+    Ok(())
 }


### PR DESCRIPTION
- fix: force rerun of failed build
- chore(release): 1.5.1 [skip ci]
- fix: skip pin configuration thats crashing the mcu
- fix: uid output formatting
- chore(release): 1.5.2 [skip ci]
- fix: correct the size of the format buffer
- fix: format hex with preceeding 0
- fix: improve error handling for device_get response
