### PR TITLE
interactive logging fix

### DIFF
--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -628,7 +628,6 @@ impl DataLogger {
                             match util::format_decimal(value) {
                                 Ok((buf,size)) => {
                                     let decimal = unsafe { core::str::from_utf8_unchecked(&buf[..size]) };
-                                    board.delay_ms(1000);
                                     let output = format_args!("{}", decimal );
                                     board.usb_serial_send(output);
                                 },


### PR DESCRIPTION
- fix: write headers to sd card when interactive logging starts
- fix: remove debugging delay
