### PR TITLE
preview pwm

### DIFF
--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -97,6 +97,7 @@ pub trait RRIVBoard: Send {
 
 
     fn write_gpio_pin(&mut self, pin: u8, value: bool);
+    fn write_pwm_pin_duty(&mut self, value: u8);
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()>;
 
     fn set_gpio_pin_mode(&mut self, pin: u8, mode: GpioMode);

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -98,6 +98,7 @@ pub trait RRIVBoard: Send {
 
     fn write_gpio_pin(&mut self, pin: u8, value: bool);
     fn write_pwm_pin_duty(&mut self, value: u8);
+    fn write_pwm_pin_period(&mut self, period_ms: u32);
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()>;
 
     fn set_gpio_pin_mode(&mut self, pin: u8, mode: GpioMode);

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -774,6 +774,11 @@ impl RRIVBoard for Board {
         }
     }
 
+    fn write_pwm_pin_period(&mut self, period_ms: u32){
+        if let Some(pwm) = &mut self.pwm {
+            pwm.set_period(ms(period_ms).into_rate());
+        }
+    }
 
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()> {
         match pin {

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1004,7 +1004,7 @@ pub struct BoardBuilder {
     pub watchdog: Option<IndependentWatchdog>,
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5],
-    pub clocks: Option<Clocks>
+    pub clocks: Option<Clocks>,
     pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>
 }
 
@@ -1029,7 +1029,7 @@ impl BoardBuilder {
             watchdog: None,
             counter: None,
             hardware_errors: [HardwareError::None; 5],
-            clocks: None
+            clocks: None,
             pwm: None
         }
     }

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1046,7 +1046,7 @@ impl BoardBuilder {
             i2c2: self.i2c2.unwrap(),
             delay: self.delay.unwrap(),
             precise_delay: self.precise_delay.unwrap(),
-            gpio: gpio,
+            gpio: self.gpio.unwrap(),
             gpio_cr: gpio_cr,
             // // power_control: self.power_control.unwrap(),
             internal_adc: internal_adc,

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -726,10 +726,10 @@ impl RRIVBoard for Board {
 
     fn write_gpio_pin(&mut self, pin: u8, value: bool) {
         match pin {
-            1 => {
-                let gpio = &mut self.gpio.gpio1;
-                write_gpio!(gpio, value);
-            }
+            // 1 => {
+            //     let gpio = &mut self.gpio.gpio1;
+            //     write_gpio!(gpio, value);
+            // }
             2 => {
                 let gpio = &mut self.gpio.gpio2;
                 write_gpio!(gpio, value);
@@ -777,10 +777,10 @@ impl RRIVBoard for Board {
 
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()> {
         match pin {
-            1 => {
-                let pin =  &mut self.gpio.gpio1;
-                return read_pin!(pin);
-            },
+            // 1 => {
+            //     let pin =  &mut self.gpio.gpio1;
+            //     return read_pin!(pin);
+            // },
             2 => {
                 let pin =  &mut self.gpio.gpio2;
                 return read_pin!(pin);
@@ -818,11 +818,11 @@ impl RRIVBoard for Board {
     fn set_gpio_pin_mode(&mut self, pin: u8, mode: rriv_board::gpio::GpioMode) {
 
         match pin {
-            1 => {
-                let cr = &mut self.gpio_cr.gpiob_crh;
-                let pin: &mut Pin<'B', 8, Dynamic> = &mut self.gpio.gpio1;
-                set_pin_mode!(pin, cr, mode);
-            }
+            // 1 => {
+            //     // let cr = &mut self.gpio_cr.gpiob_crh;
+            //     // let pin: &mut Pin<'B', 8, Dynamic> = &mut self.gpio.gpio1;
+            //     // set_pin_mode!(pin, cr, mode);
+            // }
             2 => {
                 let cr = &mut self.gpio_cr.gpiob_crl;
                 let pin = &mut self.gpio.gpio2;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -5,9 +5,10 @@ extern crate alloc;
 use alloc::boxed::Box;
 use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
-use rriv_board::hardware_error::{HardwareError};
+
+use rriv_board::hardware_error::HardwareError;
 use stm32f1xx_hal::time::MilliSeconds;
-use stm32f1xx_hal::timer::CounterUs;
+use stm32f1xx_hal::timer::{Ch, CounterUs, PwmHz, Tim4NoRemap};
 
 use core::fmt::{self};
 use core::mem;
@@ -126,8 +127,9 @@ pub struct Board {
     one_wire_search_state: Option<SearchState>,
     pub watchdog: IndependentWatchdog,
     pub counter: CounterUs<TIM5>,
-    pub hardware_errors: [HardwareError; 5]
+    pub hardware_errors: [HardwareError; 5],
     pub clocks: Clocks,
+    pub pwm: Option<Box<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>>,
 }
 
 impl Board {
@@ -761,6 +763,10 @@ impl RRIVBoard for Board {
         };
     }
     
+    fn write_pwm_pin_duty(&mut self, value: u8){
+    }
+
+
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()> {
         match pin {
             1 => {
@@ -989,7 +995,7 @@ pub struct BoardBuilder {
     pub storage: Option<Storage>,
     pub watchdog: Option<IndependentWatchdog>,
     pub counter: Option<CounterUs<TIM5>>,
-    hardware_errors: [HardwareError; 5]
+    hardware_errors: [HardwareError; 5],
     pub clocks: Option<Clocks>
 }
 
@@ -1013,7 +1019,7 @@ impl BoardBuilder {
             storage: None,
             watchdog: None,
             counter: None,
-            hardware_errors: [HardwareError::None; 5]
+            hardware_errors: [HardwareError::None; 5],
             clocks: None
         }
     }
@@ -1062,8 +1068,9 @@ impl BoardBuilder {
             one_wire_search_state: None,
             watchdog: watchdog,
             counter: self.counter.unwrap(),
-            hardware_errors: self.hardware_errors
+            hardware_errors: self.hardware_errors,
             clocks: self.clocks.unwrap(),
+            pwm: None,
         }
     }
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -148,6 +148,28 @@ impl Board {
         // self.get_sensor_driver_services().set_gpio_pin_mode(2, rriv_board::gpio::GpioMode::PushPullOutput);
         // self.get_sensor_driver_services().write_gpio_pin(2, false);
         // defmt::println!("pin 2 set up"); rriv_board::RRIVBoard::delay_ms(self, 1000);
+
+
+        // hard code a pwm pin
+        let clocks = self.clocks;
+        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+        let tim4 = device_peripherals.TIM4;
+        let mut afio = device_peripherals.AFIO.constrain();
+        let pin = &mut self.gpio.gpio1;
+        pin.make_open_drain_output(&mut self.gpio_cr.gpiob_crh);  // Dynamic pin not recognized by the HAL pwm construct
+
+
+        // just steal the damn pins.
+        // this pin is not actually moved by the pwm construct, just used as a template generic
+        let gpiob = device_peripherals.GPIOB.split();
+        let pin = gpiob.pb8.into_alternate_open_drain(&mut self.gpio_cr.gpiob_crh);
+    
+        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
+            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
+        pwm.enable(Channel::C3);
+        pwm.set_period(ms(500).into_rate());
+        self.pwm = Some(Box::new(pwm));
+
         defmt::println!("board started");
 
     }
@@ -764,6 +786,12 @@ impl RRIVBoard for Board {
     }
     
     fn write_pwm_pin_duty(&mut self, value: u8){
+        if let Some(pwm) = &mut self.pwm {
+            let max = pwm.get_max_duty();
+            let x1 = max as u32 * (value as u32);
+            let x2 = x1 / 255;
+            pwm.set_duty(Channel::C3, x2 as u16);
+        }
     }
 
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1034,10 +1034,6 @@ impl BoardBuilder {
             }
         };
 
-        // TODO: just one GPIO pin for the moment
-        let mut gpio = self.gpio.unwrap();
-        gpio.gpio6.make_push_pull_output(&mut gpio_cr.gpioc_crh);
-
         let mut watchdog = self.watchdog.unwrap();
         watchdog.feed();
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -7,8 +7,8 @@ use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
 
 use rriv_board::hardware_error::HardwareError;
-use stm32f1xx_hal::time::MilliSeconds;
-use stm32f1xx_hal::timer::{Ch, CounterUs, PwmHz, Tim4NoRemap};
+use stm32f1xx_hal::time::{MilliSeconds, ms};
+use stm32f1xx_hal::timer::{Ch, Channel, CounterUs, PwmHz, Tim4NoRemap};
 
 use core::fmt::{self};
 use core::mem;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use cortex_m::{
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
-use stm32f1xx_hal::gpio::{Alternate, Pin};
+use stm32f1xx_hal::gpio::{Alternate, Pin, PushPull};
 use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
@@ -129,7 +129,7 @@ pub struct Board {
     pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5],
     pub clocks: Clocks,
-    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>,
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>>>,
 }
 
 impl Board {
@@ -1005,7 +1005,7 @@ pub struct BoardBuilder {
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5],
     pub clocks: Option<Clocks>,
-    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>>>
 }
 
 impl BoardBuilder {
@@ -1299,11 +1299,11 @@ impl BoardBuilder {
 
         let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
         let gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
-        let pin = gpiob.pb8.into_alternate_open_drain(&mut gpio_cr.gpiob_crh);
+        let pin = gpiob.pb8.into_alternate_push_pull(&mut gpio_cr.gpiob_crh);
  
 
         let tim4 = device_peripherals.TIM4;
-        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
+        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
             tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
         pwm.set_period(ms(500).into_rate());

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -127,6 +127,7 @@ pub struct Board {
     pub watchdog: IndependentWatchdog,
     pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5]
+    pub clocks: Clocks,
 }
 
 impl Board {
@@ -989,6 +990,7 @@ pub struct BoardBuilder {
     pub watchdog: Option<IndependentWatchdog>,
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5]
+    pub clocks: Option<Clocks>
 }
 
 impl BoardBuilder {
@@ -1012,6 +1014,7 @@ impl BoardBuilder {
             watchdog: None,
             counter: None,
             hardware_errors: [HardwareError::None; 5]
+            clocks: None
         }
     }
 
@@ -1060,6 +1063,7 @@ impl BoardBuilder {
             watchdog: watchdog,
             counter: self.counter.unwrap(),
             hardware_errors: self.hardware_errors
+            clocks: self.clocks.unwrap(),
         }
     }
 
@@ -1501,8 +1505,8 @@ impl BoardBuilder {
 
         self.watchdog = Some(watchdog);
 
-        defmt::println!("setting up RS485 serial b");
-        setup_serialb(device_peripherals.UART5, &clocks);
+
+        self.clocks = Some(clocks);
 
         defmt::println!("done with setup");
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
 use stm32f1xx_hal::gpio::Pin;
-use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, USART2, USB};
+use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
 use stm32f1xx_hal::{
@@ -125,7 +125,7 @@ pub struct Board {
     pub one_wire_bus: Option<OneWire<OneWirePin<Pin<'C', 0, Dynamic>>>>,
     one_wire_search_state: Option<SearchState>,
     pub watchdog: IndependentWatchdog,
-    pub counter: CounterUs<TIM4>,
+    pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5]
 }
 
@@ -987,7 +987,7 @@ pub struct BoardBuilder {
     pub internal_rtc: Option<Rtc>,
     pub storage: Option<Storage>,
     pub watchdog: Option<IndependentWatchdog>,
-    pub counter: Option<CounterUs<TIM4>>,
+    pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5]
 }
 
@@ -1490,7 +1490,7 @@ impl BoardBuilder {
         self.precise_delay = Some(precise_delay);
 
         // the millis counter
-        let mut counter: CounterUs<TIM4> = device_peripherals.TIM4.counter_us(&clocks);
+        let mut counter: CounterUs<TIM5> = device_peripherals.TIM5.counter_us(&clocks);
         match counter.start(2.micros()) {
             Ok(_) => defmt::println!("Millis counter start ok"),
             Err(err) => defmt::println!("Millis counter start not ok {:?}", defmt::Debug2Format(&err)),

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1540,6 +1540,8 @@ impl BoardBuilder {
 
         self.watchdog = Some(watchdog);
 
+        // defmt::println!("setting up RS485 serial b");
+        // setup_serialb(device_peripherals.UART5, &clocks);
 
         self.clocks = Some(clocks);
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1306,7 +1306,8 @@ impl BoardBuilder {
         let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
             tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
-        pwm.set_period(ms(500).into_rate());
+        pwm.set_period(ms(10).into_rate());
+        pwm.set_duty(Channel::C3, 0u16);
         self.pwm = Some(pwm);
 
         // let mut high = true;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use cortex_m::{
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
-use stm32f1xx_hal::gpio::Pin;
+use stm32f1xx_hal::gpio::{Alternate, Pin};
 use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
@@ -129,7 +129,7 @@ pub struct Board {
     pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5],
     pub clocks: Clocks,
-    pub pwm: Option<Box<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>>,
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>,
 }
 
 impl Board {
@@ -149,27 +149,7 @@ impl Board {
         // self.get_sensor_driver_services().write_gpio_pin(2, false);
         // defmt::println!("pin 2 set up"); rriv_board::RRIVBoard::delay_ms(self, 1000);
 
-
-        // hard code a pwm pin
-        let clocks = self.clocks;
-        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
-        let tim4 = device_peripherals.TIM4;
-        let mut afio = device_peripherals.AFIO.constrain();
-        let pin = &mut self.gpio.gpio1;
-        pin.make_open_drain_output(&mut self.gpio_cr.gpiob_crh);  // Dynamic pin not recognized by the HAL pwm construct
-
-
-        // just steal the damn pins.
-        // this pin is not actually moved by the pwm construct, just used as a template generic
-        let gpiob = device_peripherals.GPIOB.split();
-        let pin = gpiob.pb8.into_alternate_open_drain(&mut self.gpio_cr.gpiob_crh);
-    
-        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
-            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
-        pwm.enable(Channel::C3);
-        pwm.set_period(ms(500).into_rate());
-        self.pwm = Some(Box::new(pwm));
-
+        self.delay_ms(2000);
         defmt::println!("board started");
 
     }
@@ -1025,6 +1005,7 @@ pub struct BoardBuilder {
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5],
     pub clocks: Option<Clocks>
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>
 }
 
 impl BoardBuilder {
@@ -1049,6 +1030,7 @@ impl BoardBuilder {
             counter: None,
             hardware_errors: [HardwareError::None; 5],
             clocks: None
+            pwm: None
         }
     }
 
@@ -1098,7 +1080,7 @@ impl BoardBuilder {
             counter: self.counter.unwrap(),
             hardware_errors: self.hardware_errors,
             clocks: self.clocks.unwrap(),
-            pwm: None,
+            pwm: Some(self.pwm.unwrap()),
         }
     }
 
@@ -1314,6 +1296,18 @@ impl BoardBuilder {
         let clocks =
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
 
+
+        let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+        let gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+        let pin = gpiob.pb8.into_alternate_open_drain(&mut gpio_cr.gpiob_crh);
+ 
+
+        let tim4 = device_peripherals.TIM4;
+        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
+            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
+        pwm.enable(Channel::C3);
+        pwm.set_period(ms(500).into_rate());
+        self.pwm = Some(pwm);
 
         // let mut high = true;
         let precise_delay = PreciseDelayUs::new();

--- a/board/rriv_board_0_4_2/src/pin_groups/dynamic_gpio.rs
+++ b/board/rriv_board_0_4_2/src/pin_groups/dynamic_gpio.rs
@@ -2,7 +2,7 @@ use stm32f1xx_hal::gpio::*;
 use crate::pins::*;
 
 pub struct DynamicGpioPins {
-    pub gpio1: Pin<'B', 8, Dynamic>,
+    pub gpio1: Pin<'B', 8, Alternate<OpenDrain>>,
     pub gpio2: Pin<'B', 5, Dynamic>,
     pub gpio3: Pin<'B', 4, Dynamic>,
     pub gpio4: Pin<'B', 3, Dynamic>,
@@ -25,7 +25,7 @@ impl DynamicGpioPins {
         cr: &mut GpioCr,
     ) -> Self {
         return DynamicGpioPins {
-            gpio1: gpio1.into_dynamic(&mut cr.gpiob_crh),
+            gpio1: gpio1.into_alternate_open_drain(&mut cr.gpiob_crh),
             gpio2: gpio2.into_dynamic(&mut cr.gpiob_crl),
             gpio3: gpio3.into_dynamic(&mut cr.gpiob_crl),
             gpio4: gpio4.into_dynamic(&mut cr.gpiob_crl),

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -5,7 +5,7 @@ use crate::sensor_name_from_type_id;
 
 use super::types::*;
 
-const MAX_MILLIS: u32 = 65535;
+// const MAX_MILLIS: u32 = 65535;
 #[derive(Copy, Clone)]
 pub struct TimedSwitch2SpecialConfiguration {
     on_time_s: usize,
@@ -324,7 +324,7 @@ impl SensorDriver for TimedSwitch2 {
 
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
         let timestamp = board.timestamp();
-        let millis = board.millis();
+        // let millis = board.millis();
 
         let mut gpio_state = false;
         let mut toggle_state = false;
@@ -340,8 +340,8 @@ impl SensorDriver for TimedSwitch2 {
                 toggle_state = true;
                 gpio_state = true;
                 self.state = 1;
-                self.last_duty_cycle_update = millis;
-                self.duty_cycle_state = true;
+                // self.last_duty_cycle_update = millis;
+                // self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
             }
         } else if self.state == 1 {
@@ -349,27 +349,28 @@ impl SensorDriver for TimedSwitch2 {
             if self.special_config.pwm_enable {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
-            } else if self.special_config.pwm_enable {
-            // duty cycle implementation
-                let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
-                let mut new_elapsed: u32 = elapsed as u32;
-                if elapsed < 0 {
-                    // millis overflowed
-                    new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
-                }
+            } 
+            // else if self.special_config.pwm_enable {
+            // // duty cycle implementation
+            //     let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
+            //     let mut new_elapsed: u32 = elapsed as u32;
+            //     if elapsed < 0 {
+            //         // millis overflowed
+            //         new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
+            //     }
                 
-                if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
-                    toggle_state = true;
-                    gpio_state = false;
-                    self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state  = false;
-                } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
-                    toggle_state = true;
-                    gpio_state = true;
-                    self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state  = true;
-                } 
-            }
+            //     if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
+            //         toggle_state = true;
+            //         gpio_state = false;
+            //         self.last_duty_cycle_update = millis;
+            //         self.duty_cycle_state  = false;
+            //     } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
+            //         toggle_state = true;
+            //         gpio_state = true;
+            //         self.last_duty_cycle_update = millis;
+            //         self.duty_cycle_state  = true;
+            //     } 
+            // }
             // end of on_time (outer cycle)
             if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
                 defmt::println!("state is 1, toggle triggered");

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -282,6 +282,11 @@ impl SensorDriver for TimedSwitch2 {
             };
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
+        else {
+            let period_ms = (self.special_config.period * 1000.0) as u32;
+            defmt::println!("Setting PWM period to {} ms", period_ms);
+            board.write_pwm_pin_period(period_ms);
+        }
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
         self.duty_cycle_state = self.state == 1;

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -89,6 +89,19 @@ impl TimedSwitch2SpecialConfiguration {
             }
         }
 
+        match &values["pwm_type"] {
+            serde_json::Value::String(s) => {
+                let pwm_type: bool = match s.to_ascii_lowercase().as_str() {
+                    "hw" => true,
+                    "sw" => false,
+                    _ => true,
+                };
+                self.pwm_type = pwm_type;
+                return Ok(());
+            },
+            _ => {}
+        }
+
         match &values["period"] {
             serde_json::Value::Number(number) => {
                 if let Some(number) = number.as_f64() {

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -287,12 +287,12 @@ impl TimedSwitch2 {
 
 impl SensorDriver for TimedSwitch2 {
     fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        self.state = match self.special_config.initial_state {
+            true => 1,
+            false => 0,
+        };
         if !self.special_config.pwm_type {
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
-            self.state = match self.special_config.initial_state {
-                true => 1,
-                false => 0,
-            };
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
         else if self.special_config.pwm_enable && self.special_config.pwm_type {

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -5,7 +5,7 @@ use crate::sensor_name_from_type_id;
 
 use super::types::*;
 
-// const MAX_MILLIS: u32 = 65535;
+const MAX_MILLIS: u32 = 65535;
 #[derive(Copy, Clone)]
 pub struct TimedSwitch2SpecialConfiguration {
     on_time_s: usize,
@@ -14,6 +14,7 @@ pub struct TimedSwitch2SpecialConfiguration {
     initial_state: bool, // 'on' 'off'
     // polarity // 'low_is_on', 'high_is_on'
     pwm_enable: bool,
+    pwm_type: bool,
     period: f32,
     ratio: f32,
     _empty: [u8; 13],
@@ -195,6 +196,17 @@ impl TimedSwitch2SpecialConfiguration {
             }
         }
 
+        let s = match &value["pwm_type"] {
+            serde_json::Value::String(s) => s.as_str(),
+            _ => "hw"
+        };
+        
+        let pwm_type: bool = match s.to_ascii_lowercase().as_str() {
+            "hw" => true,
+            "sw" => false,
+            _ => true,
+        };
+
         let mut period: f32 = 10.0;
         match &value["period"] {
             serde_json::Value::Number(number) => {
@@ -228,6 +240,7 @@ impl TimedSwitch2SpecialConfiguration {
             gpio_pin,
             initial_state,
             pwm_enable,
+            pwm_type,
             period,
             ratio,
             _empty: [b'\0'; 13],
@@ -274,7 +287,7 @@ impl TimedSwitch2 {
 
 impl SensorDriver for TimedSwitch2 {
     fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        if ! self.special_config.pwm_enable {
+        if !self.special_config.pwm_type {
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
             self.state = match self.special_config.initial_state {
                 true => 1,
@@ -282,7 +295,7 @@ impl SensorDriver for TimedSwitch2 {
             };
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
-        else {
+        else if self.special_config.pwm_enable && self.special_config.pwm_type {
             let period_ms = (self.special_config.period * 1000.0) as u32;
             defmt::println!("Setting PWM period to {} ms", period_ms);
             board.write_pwm_pin_period(period_ms);
@@ -329,13 +342,13 @@ impl SensorDriver for TimedSwitch2 {
 
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
         let timestamp = board.timestamp();
-        // let millis = board.millis();
+        let millis = board.millis();
 
         let mut gpio_state = false;
         let mut toggle_state = false;
         if self.state == 0 {
             // heater is off
-            if self.special_config.pwm_enable {
+            if self.special_config.pwm_enable && self.special_config.pwm_type {
                 // chip produced pwm on pin 1 only
                 board.write_pwm_pin_duty(0);
             }
@@ -345,37 +358,37 @@ impl SensorDriver for TimedSwitch2 {
                 toggle_state = true;
                 gpio_state = true;
                 self.state = 1;
-                // self.last_duty_cycle_update = millis;
-                // self.duty_cycle_state = true;
+                self.last_duty_cycle_update = millis;
+                self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
             }
         } else if self.state == 1 {
             // heater is on
-            if self.special_config.pwm_enable {
+            if self.special_config.pwm_enable && self.special_config.pwm_type {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
             } 
-            // else if self.special_config.pwm_enable {
-            // // duty cycle implementation
-            //     let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
-            //     let mut new_elapsed: u32 = elapsed as u32;
-            //     if elapsed < 0 {
-            //         // millis overflowed
-            //         new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
-            //     }
+            else if self.special_config.pwm_enable && !self.special_config.pwm_type {
+            // duty cycle implementation
+                let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
+                let mut new_elapsed: u32 = elapsed as u32;
+                if elapsed < 0 {
+                    // millis overflowed
+                    new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
+                }
                 
-            //     if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
-            //         toggle_state = true;
-            //         gpio_state = false;
-            //         self.last_duty_cycle_update = millis;
-            //         self.duty_cycle_state  = false;
-            //     } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
-            //         toggle_state = true;
-            //         gpio_state = true;
-            //         self.last_duty_cycle_update = millis;
-            //         self.duty_cycle_state  = true;
-            //     } 
-            // }
+                if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
+                    toggle_state = true;
+                    gpio_state = false;
+                    self.last_duty_cycle_update = millis;
+                    self.duty_cycle_state  = false;
+                } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
+                    toggle_state = true;
+                    gpio_state = true;
+                    self.last_duty_cycle_update = millis;
+                    self.duty_cycle_state  = true;
+                } 
+            }
             // end of on_time (outer cycle)
             if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
                 defmt::println!("state is 1, toggle triggered");

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -730,12 +730,6 @@ impl DataLogger {
     }
 
     fn write_last_measurement_to_serial(&mut self, board: &mut impl rriv_board::RRIVBoard) {
-        // first output the column headers
-        match self.serial_tx_mode {
-            DataLoggerSerialTxMode::Interactive => self.write_column_headers_to_serial(board),
-            _ => {}
-        }
-
         // then output the last measurement values
         match self.serial_tx_mode {
             DataLoggerSerialTxMode::Watch => self.write_measured_parameters_to_serial(board),


### PR DESCRIPTION
Hardware PWM is now enabled on gpio-1. We can continue using the old software PWM using the config parameter
```json
"pwm_type" : "sw"  // ("hw" for hardware pwm)
```

By default it is in the hardware PWM mode.