### PR TITLE
sdi12 wip

### DIFF
--- a/board/Cargo.lock
+++ b/board/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "one-wire-bus",
  "rriv_board",
  "rtt-target",
+ "sdi12",
  "serde",
  "serde_json",
  "util",
@@ -541,6 +542,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdi12"
+version = "0.1.0"
+dependencies = [
+ "defmt 1.0.1",
+ "format_no_std",
+ "rriv_board",
+ "rtt-target",
+]
 
 [[package]]
 name = "semver"

--- a/board/app/Cargo.toml
+++ b/board/app/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m-rt = "0.7.3"
 unwrap-infallible = "0.1.5"
 rtt-target = { version = "0.6.1", features =  ["defmt"] }
 embedded-alloc = "0.5.0"
-rriv_board_0_4_2 = { path = "../rriv_board_0_4_2" }
+rriv_board_0_4_2 = { path = "../rriv_board_0_4_2", features=["disable-storage"] }
 datalogger = { path = "../../src/datalogger" }
 rriv_board = { path = "../rriv_board", features = ["24LC08"]}
 defmt = "1.0.1"

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -66,6 +66,7 @@ pub trait RRIVBoard: Send {
     fn rs485_send(&mut self, message : &[u8]);
     fn serial_debug(&mut self, args: fmt::Arguments);
     fn delay_ms(&mut self, ms: u16);
+    fn delay_us(&mut self, us: u16);
     fn timestamp(&mut self) -> i64;
     fn millis(&mut self) -> u32;
 

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -20,6 +20,7 @@ pub const EEPROM_TOTAL_SENSOR_SLOTS: usize = 12;
 #[cfg(feature = "24LC01")]
 pub const EEPROM_TOTAL_SENSOR_SLOTS: usize = 2;
 
+
 pub trait RXProcessor: Send + Sync {
     fn process_byte(&mut self, byte: u8);
 }

--- a/board/rriv_board_0_4_2/Cargo.toml
+++ b/board/rriv_board_0_4_2/Cargo.toml
@@ -27,3 +27,9 @@ i2c_hung_fix = "0.1.0"
 bitfield-struct = "0.11.0"
 format_no_std = "1.2.0"
 defmt = "1.0.1"
+
+
+[features]
+default = ["storage"]
+disable-storage = []
+storage = []

--- a/board/rriv_board_0_4_2/src/components/precise_delay.rs
+++ b/board/rriv_board_0_4_2/src/components/precise_delay.rs
@@ -18,7 +18,7 @@ impl PreciseDelayUs {
 impl DelayUs<u16> for PreciseDelayUs {
     fn delay_us(&mut self, us: u16) {
         unsafe {
-            let real_cyc = (us * PER_MICROSEC) as u32 / 4;
+            let real_cyc = (us as u32 * PER_MICROSEC as u32) / 4;
             asm!(
                 // Use local labels to avoid R_ARM_THM_JUMP8 relocations which fail on thumbv6m.
                 "1:",

--- a/board/rriv_board_0_4_2/src/components/uart5.rs
+++ b/board/rriv_board_0_4_2/src/components/uart5.rs
@@ -126,7 +126,7 @@ unsafe fn UART5() {
             // do a read from the sr register followed by a read from the dr register.
             let _ = usart.sr.read();
             let _ = usart.dr.read();
-            defmt::println!("uart5 error {:?}", defmt::Debug2Format(&err));
+            // defmt::println!("uart5 error {:?}", defmt::Debug2Format(&err));
             // Err(nb::Error::Other(err))
         } else {
             // Check if a byte is available

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -378,6 +378,10 @@ impl RRIVBoard for Board {
         self.delay.delay_ms(ms);
     }
 
+    fn delay_us(&mut self, us: u16) {
+        self.precise_delay.delay_us(us);
+    }
+
     fn set_epoch(&mut self, epoch: i64) {
         let i2c1 = mem::replace(&mut self.i2c1, None);
         let mut ds3231 = Ds323x::new_ds3231(i2c1.unwrap());

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1155,10 +1155,46 @@ impl BoardBuilder {
 
             USB_SERIAL = Some(SerialPort::new(USB_BUS.as_ref().unwrap()));
 
+            let uid: [u8;12] = Uid::fetch().bytes();
+            
+            let arg = format_args!("{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",            
+                    uid[0],
+                    uid[1],
+                    uid[2],
+                    uid[3],
+                    uid[4],
+                    uid[5],
+                    uid[6],
+                    uid[7],
+                    uid[8],
+                    uid[9],
+                    uid[10],
+                    uid[11]);
+
+            
+            #[allow(unused_assignments)]
+            let mut uid_string: &str = "_rriv";
+            static mut BUF:[u8;24] = [0u8; 24];
+
+            match format_no_std::show(
+                    &mut BUF,
+                    arg 
+                ) {
+                    Ok(formatted) => {
+                        defmt::println!("{}", formatted); // TODO: this uses format!
+                        // uid_string = formatted;s
+                    }
+                    Err(e) => {
+                        // doesn't matter
+                    },
+                }
+
+            defmt::println!("{}", uid_string);
+
             let usb_dev = UsbDeviceBuilder::new(USB_BUS.as_ref().unwrap(), UsbVidPid(0x0483, 0x29))
                 .manufacturer("RRIV")
                 .product("RRIV Data Logger")
-                .serial_number("_rriv")
+                .serial_number(uid_string)
                 .device_class(USB_CLASS_CDC)
                 .build();
 
@@ -1309,16 +1345,27 @@ impl BoardBuilder {
         usb_serial_send("{\"status\":\"usb started up\"}\n", &mut delay);
 
         let delay2: DelayUs<TIM2> = device_peripherals.TIM2.delay(&clocks);
-        watchdog.start(MilliSeconds::secs(24));
-        let storage = storage::build(spi2_pins, device_peripherals.SPI2, clocks, delay2);
-        watchdog.start(MilliSeconds::secs(6));
-        let storage = match storage {
-            Ok(storage) => Some(storage),
-            Err(hardware_error) => {
-                add_hardware_error(&mut self.hardware_errors, hardware_error);
-                None
-            },
-        };
+
+        let mut enable_storage = true;
+        let storage = None;
+        #[cfg(feature = "disable-storage")]
+        {
+            enable_storage = false;
+        }
+
+        if enable_storage {
+            watchdog.start(MilliSeconds::secs(24));
+            let result = storage::build(spi2_pins, device_peripherals.SPI2, clocks, delay2);
+            watchdog.start(MilliSeconds::secs(6));
+            let storage = match result {
+                Ok(storage) => Some(storage),
+                Err(hardware_error) => {
+                    add_hardware_error(&mut self.hardware_errors, hardware_error);
+                    None
+                },
+            };
+
+        }
         if storage.is_none() {
             // sd card library has no way to release the spi and pins
             // so unsafely get the cs pin and flash it
@@ -1539,7 +1586,7 @@ pub fn usb_serial_send(string: &str, delay: &mut impl DelayMs<u16>) {
                     match err {
                         UsbError::WouldBlock => {
                             if would_block_count > 100 {
-                                defmt::println!("USBWouldBlock limit exceeded");
+                                // defmt::println!("USBWouldBlock limit exceeded");
                                 return;
                             }
                             would_block_count = would_block_count + 1; // handle hung blocking condition.  possibly caused by client not reading and buffer full.

--- a/src/datalogger/Cargo.toml
+++ b/src/datalogger/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rriv_board = { path = "../../board/rriv_board" } 
 control_interface = { path = "../../src/control_interface" }
 util = { path = "../../src/util"}
+sdi12 = { path = "../../src/sdi12"}
 hashbrown = { version="0.14", default-features=false }
 serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/src/datalogger/src/datalogger/modes.rs
+++ b/src/datalogger/src/datalogger/modes.rs
@@ -4,7 +4,8 @@
 pub enum DataLoggerMode {
     Interactive = 1,
     Field = 2,
-    HibernateUntil = 3
+    HibernateUntil = 3,
+    SDI12 = 4,
 }
 
 impl DataLoggerMode {
@@ -26,6 +27,7 @@ pub fn mode_text(mode: &DataLoggerMode) -> &'static str {
         DataLoggerMode::Interactive => "interactive",
         DataLoggerMode::Field => "field",
         DataLoggerMode::HibernateUntil => "hibernate",
+        DataLoggerMode::SDI12 => "sdi12",
     }
 }
 

--- a/src/datalogger/src/datalogger/modes.rs
+++ b/src/datalogger/src/datalogger/modes.rs
@@ -17,6 +17,7 @@ impl DataLoggerMode {
     match index {
         2 => DataLoggerMode::Field,
         3 => DataLoggerMode::HibernateUntil,
+        4 => DataLoggerMode::SDI12,
         _ => DataLoggerMode::Interactive
     }
   }

--- a/src/datalogger/src/datalogger/payloads.rs
+++ b/src/datalogger/src/datalogger/payloads.rs
@@ -21,6 +21,7 @@ pub struct DataloggerSettingsValues {
     pub enable_lorawan_telemetry: Option<bool>,
     pub enable_modbus_rtu: Option<bool>,
     pub interactive_logging: Option<bool>,
+    pub enable_sdi12: Option<bool>
 }
 
 #[derive(Serialize, Deserialize)]
@@ -38,6 +39,7 @@ pub struct DataloggerSetPayload {
     pub enable_lorawan_telemetry: Option<bool>,
     pub enable_modbus_rtu: Option<bool>,
     pub interactive_logging: Option<bool>,
+    pub enable_sdi12: Option<bool>,
     // pub user_note: Option<Value>, // not implemented for now
     // pub user_value: Option<i16>
 }
@@ -114,6 +116,9 @@ impl DataloggerSetPayload {
             datalogger_settings_values.enable_modbus_rtu = Some(enable_modbus_rtu);
         }
 
+        if let Some(enable_sdi12) = self.enable_sdi12 {
+            datalogger_settings_values.enable_sdi12 = Some(enable_sdi12);
+        }
 
         datalogger_settings_values
     }

--- a/src/datalogger/src/datalogger/settings.rs
+++ b/src/datalogger/src/datalogger/settings.rs
@@ -31,7 +31,7 @@ pub struct DataloggerSettingsBitField {
     pub enable_interactive_logging: bool,
 
     #[bits(1)]
-    unused: usize,
+    pub enable_sdi12: bool,
 }
 
 
@@ -142,6 +142,7 @@ impl DataloggerSettings {
         settings.toggles.set_enable_lorawan_telemetry(values.enable_lorawan_telemetry.unwrap_or(self.toggles.enable_lorawan_telemetry()));
         settings.toggles.set_enable_modbus_rtu(values.enable_modbus_rtu.unwrap_or(self.toggles.enable_modbus_rtu()));
         settings.toggles.set_enable_interactive_logging(values.interactive_logging.unwrap_or(self.toggles.enable_interactive_logging()));
+        settings.toggles.set_enable_sdi12(values.enable_sdi12.unwrap_or(self.toggles.enable_sdi12()));
         settings
     }
 

--- a/src/datalogger/src/datalogger/settings.rs
+++ b/src/datalogger/src/datalogger/settings.rs
@@ -9,28 +9,28 @@ const DATALOGGER_SETTINGS_UNUSED_BYTES: usize = 13;
 #[bitfield(u8)]
 #[derive(PartialEq)]
 pub struct DataloggerSettingsBitField {
-    #[bits(1)]
+    #[bits(1, default = true)]
     pub external_adc_enabled: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_lorawan_telemetry: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_modbus_rtu: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub debug_includes_values: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub withhold_incomplete_readings: bool,
 
-    #[bits(1)]
+    #[bits(1, default = true)]
     pub log_raw_data: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_interactive_logging: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_sdi12: bool,
 }
 

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -1,0 +1,59 @@
+use crate::drivers::types::SensorDriver;
+
+
+struct MyDigitalPin {
+    pub func new(&mut board);
+    pub func release() -> &mut board;
+}
+
+impl digital_pin for MyDigitalPin {
+    // the write and read functions
+}
+
+struct GroundwaterFlowSDI12 {
+
+}
+
+
+impl SensorDriver for GroundwaterFlowSDI12 {
+    fn get_configuration_bytes(&self, storage: &mut [u8; rriv_board::EEPROM_SENSOR_SETTINGS_SIZE]) {
+        todo!()
+    }
+
+    fn get_configuration_json(&mut self) -> serde_json::Value {
+        todo!()
+    }
+
+    fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        todo!()
+    }
+
+    fn get_id(&self) -> [u8; 6] {
+        todo!()
+    }
+
+    fn get_type_id(&self) -> u16 {
+        todo!()
+    }
+
+    fn get_measured_parameter_count(&mut self) -> usize {
+        todo!()
+    }
+
+    fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
+        todo!()
+    }
+
+    fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
+        todo!()
+    }
+
+    fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        let command = "aM"; // not done
+
+        let my_digital_pin = MyDigitalPin::new(&mut board);
+
+
+        sdi12::send_command(&commmand, my_digital_pin, my_delay_us);
+    }
+}

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -139,6 +139,7 @@ impl SensorDriver for GroundwaterFlowSDI12 {
             let mut now = board.epoch_timestamp();
             let trigger = now + m_response.ttt as i64;
             while now < trigger {
+                board.usb_serial_send(format_args!("SDI12: waiting...\n"));
                 board.run_loop_iteration(); // feeds the watchdog and keeps the board layer updated
                 board.delay_ms(1000);
                 now = board.epoch_timestamp();

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -136,10 +136,12 @@ impl SensorDriver for GroundwaterFlowSDI12 {
             defmt::println!("TIMEOUT error");
             return;
         }
+        defmt::println!("Response received:\nttt: {}\tn: {}", m_response.ttt, m_response.n);
         if m_response.ttt == 0 {
             let d_response = sdi12.send_d0_command(m_response.address, m_response.n);
             self.data_received = d_response.data;
             self.num_data = d_response.count;
+            defmt::println!("Received data: {} {}", d_response.data[0], d_response.data[1]);
         }
     }
 }

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -1,8 +1,7 @@
-use crate::drivers::types::SensorDriver;
+use crate::{drivers::types::SensorDriver, services::sdi12_service};
 use sdi12::SDI12;
 use crate::sensor_name_from_type_id;
 use serde_json::json;
-use crate::sdi12_service::*;
 use super::types::*;
 
 #[derive(Copy, Clone)]
@@ -127,10 +126,8 @@ impl SensorDriver for GroundwaterFlowSDI12 {
 
     fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
 
-        let my_board = Sdi12Board::new(self.special_config.gpio, board);
-        let mut sdi12 = SDI12::new(my_board);
-
-        let m_response = sdi12.send_m_command(self.special_config.sensor_address, '0');
+        let mut sdi12_service = sdi12_service::Sdi12ByteProcessor::new(self.special_config.gpio);
+        let m_response = sdi12_service.send_m_command(board, self.special_config.sensor_address, '0');
         if m_response.address == '\0' {
             // invalid response
             defmt::println!("TIMEOUT error");
@@ -138,7 +135,7 @@ impl SensorDriver for GroundwaterFlowSDI12 {
         }
         defmt::println!("Response received:\nttt: {}\tn: {}", m_response.ttt, m_response.n);
         if m_response.ttt == 0 {
-            let d_response = sdi12.send_d0_command(m_response.address, m_response.n);
+            let d_response = sdi12_service.send_d0_command(board, m_response.address, m_response.n);
             self.data_received = d_response.data;
             self.num_data = d_response.count;
             defmt::println!("Received data: {} {}", d_response.data[0], d_response.data[1]);

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -1,59 +1,158 @@
 use crate::drivers::types::SensorDriver;
+use sdi12::SDI12;
+use crate::sensor_name_from_type_id;
+use serde_json::json;
+use crate::sdi12_service::*;
+use super::types::*;
 
-
-struct MyDigitalPin {
-    pub func new(&mut board);
-    pub func release() -> &mut board;
+#[derive(Copy, Clone)]
+pub struct GroundwaterFlowSDI12SpecialConfiguration {
+    gpio: u8,
+    sensor_address: char,
+    measured_parameter_count: usize
 }
 
-impl digital_pin for MyDigitalPin {
-    // the write and read functions
+impl GroundwaterFlowSDI12SpecialConfiguration {
+    pub fn parse_from_values(value: serde_json::Value) -> Result<GroundwaterFlowSDI12SpecialConfiguration, &'static str> {
+        
+        let gpio_pin = match &value["gpio_pin"] {
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_u64() {
+                    if number >= 1 && number <= 8 {
+                        Some(number as u8)
+                    } else {
+                        return Err("invalid pin");
+                    }           
+                } else {
+                    return Err("invalid pin");
+                }
+            }
+            _ => {
+                return Err("gpio pin is required")
+            }
+        };
+
+        let address = match &value["sensor_address"] {
+            serde_json::Value::String(s) => s.chars().next().unwrap_or('\0'),
+            _ => return Err("sensor_address must be a single character from '0' to '9'"),
+        };
+
+        let measured_parameter_count = match &value["measured_parameter_count"] {
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_u64() {
+                    if number <= 9 {
+                        number as usize
+                    } else {
+                        return Err("measured_parameter_count must be between 0 and 9");
+                    }
+                } else {
+                    return Err("invalid measured_parameter_count");
+                }
+            }
+            _ => return Err("measured_parameter_count is required"),
+        };
+
+        Ok ( Self {
+            gpio: gpio_pin.unwrap(),
+            sensor_address: address,
+            measured_parameter_count: measured_parameter_count
+        } ) 
+    }
+
+    pub fn new_from_bytes(
+        bytes: [u8; SENSOR_SETTINGS_PARTITION_SIZE],
+    ) -> GroundwaterFlowSDI12SpecialConfiguration {
+        let settings = bytes
+            .as_ptr()
+            .cast::<GroundwaterFlowSDI12SpecialConfiguration>();
+        unsafe { *settings }
+    }
 }
 
-struct GroundwaterFlowSDI12 {
-
+pub struct GroundwaterFlowSDI12 {
+    general_config: SensorDriverGeneralConfiguration,
+    special_config: GroundwaterFlowSDI12SpecialConfiguration,
+    data_received: [f32; 9],
+    num_data: u8
 }
 
 
 impl SensorDriver for GroundwaterFlowSDI12 {
-    fn get_configuration_bytes(&self, storage: &mut [u8; rriv_board::EEPROM_SENSOR_SETTINGS_SIZE]) {
-        todo!()
-    }
+
+    getters!();
 
     fn get_configuration_json(&mut self) -> serde_json::Value {
-        todo!()
+        let mut sensor_id = self.get_id();
+        let sensor_id = match util::str_from_utf8(&mut sensor_id) {
+            Ok(sensor_id) => sensor_id,
+            Err(_) => "Invalid",
+        };
+
+        let mut sensor_name = sensor_name_from_type_id(self.get_type_id().into());
+        let sensor_name = match util::str_from_utf8(&mut sensor_name) {
+            Ok(sensor_name) => sensor_name,
+            Err(_) => "Invalid",
+        };
+
+        json!({
+           "id" : sensor_id,
+           "type" : sensor_name,
+           "gpio_pin": self.special_config.gpio,
+           "sensor_address": self.special_config.sensor_address,
+           "measured_parameter_count": self.special_config.measured_parameter_count
+        })
     }
 
+    #[allow(unused)]
     fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        todo!()
-    }
-
-    fn get_id(&self) -> [u8; 6] {
-        todo!()
-    }
-
-    fn get_type_id(&self) -> u16 {
-        todo!()
+        
     }
 
     fn get_measured_parameter_count(&mut self) -> usize {
-        todo!()
+        self.special_config.measured_parameter_count
     }
 
     fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
-        todo!()
+        Ok(self.data_received[index] as f64)
     }
 
     fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
-        todo!()
+        let mut buffer = [0u8; 16];
+        buffer[0..6].copy_from_slice("value_".as_bytes());
+        let c = char::from_digit(index as u32, 10).unwrap();
+        let a = c as u8;
+        buffer[6] = a;
+        buffer
     }
 
     fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        let command = "aM"; // not done
 
-        let my_digital_pin = MyDigitalPin::new(&mut board);
+        let my_board = Sdi12Board::new(self.special_config.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
 
+        let m_response = sdi12.send_m_command(self.special_config.sensor_address, '0');
+        if m_response.address == '\0' {
+            // invalid response
+            return;
+        }
+        if m_response.ttt == 0 {
+            let d_response = sdi12.send_d0_command(m_response.address, m_response.n);
+            self.data_received = d_response.data;
+            self.num_data = d_response.count;
+        }
+    }
+}
 
-        sdi12::send_command(&commmand, my_digital_pin, my_delay_us);
+impl GroundwaterFlowSDI12 {
+    pub fn new(
+        general_config: SensorDriverGeneralConfiguration,
+        special_config: GroundwaterFlowSDI12SpecialConfiguration,
+    ) -> Self {
+        GroundwaterFlowSDI12 {
+            general_config,
+            special_config,
+            data_received: [0.0; 9],
+            num_data: 0
+        }
     }
 }

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -133,6 +133,7 @@ impl SensorDriver for GroundwaterFlowSDI12 {
         let m_response = sdi12.send_m_command(self.special_config.sensor_address, '0');
         if m_response.address == '\0' {
             // invalid response
+            defmt::println!("TIMEOUT error");
             return;
         }
         if m_response.ttt == 0 {

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -134,12 +134,21 @@ impl SensorDriver for GroundwaterFlowSDI12 {
             return;
         }
         defmt::println!("Response received:\nttt: {}\tn: {}", m_response.ttt, m_response.n);
-        if m_response.ttt == 0 {
-            let d_response = sdi12_service.send_d0_command(board, m_response.address, m_response.n);
-            self.data_received = d_response.data;
-            self.num_data = d_response.count;
-            defmt::println!("Received data: {} {}", d_response.data[0], d_response.data[1]);
+        if m_response.ttt > 0 {
+            // process the delay
+            let mut now = board.epoch_timestamp();
+            let trigger = now + m_response.ttt as i64;
+            while now < trigger {
+                board.run_loop_iteration(); // feeds the watchdog and keeps the board layer updated
+                board.delay_ms(1000);
+                now = board.epoch_timestamp();
+            }
         }
+
+        let d_response = sdi12_service.send_d0_command(board, m_response.address, m_response.n);
+        self.data_received = d_response.data;
+        self.num_data = d_response.count;
+        defmt::println!("Received data: {} {}", d_response.data[0], d_response.data[1]);
     }
 }
 

--- a/src/datalogger/src/drivers/mod.rs
+++ b/src/datalogger/src/drivers/mod.rs
@@ -16,5 +16,6 @@ pub mod aht20;
 pub mod adc_temperature;
 pub mod resources;
 pub mod modbus;
+pub mod groundwater_flow_sdi12;
 pub mod mhz9041a;
 

--- a/src/datalogger/src/drivers/mod.rs.orig
+++ b/src/datalogger/src/drivers/mod.rs.orig
@@ -1,0 +1,21 @@
+
+
+// codes and sensor names mapped to a sensor implementation
+
+pub mod types;
+pub mod mcp9808;
+pub mod generic_analog;
+pub mod ring_temperature;
+pub mod ring_w_mux;
+pub mod ring_temperature_sim;
+pub mod timed_switch_2;
+pub mod ds18b20;
+pub mod k30_co2;
+pub mod atlas_ec;
+pub mod aht20;
+pub mod adc_temperature;
+pub mod resources;
+pub mod modbus;
+pub mod mhz9041a;
+pub mod groundwater_flow_sdi12;
+

--- a/src/datalogger/src/drivers/ring_temperature.rs
+++ b/src/datalogger/src/drivers/ring_temperature.rs
@@ -114,13 +114,18 @@ impl SensorDriver for RingTemperatureDriver {
 
     // TODO: this should come from a derived trait
     fn get_configuration_json(&mut self) -> serde_json::Value {
-        // let sensor_id_str: [u8; 6] = core::str::from_utf8(self.get_id());
+
+        let mut sensor_id = self.get_id();
+        let sensor_id = match util::str_from_utf8(&mut sensor_id) {
+            Ok(sensor_id) => sensor_id,
+            Err(_) => "Invalid",
+        };
 
         let sensor_name_bytes = sensor_name_from_type_id(self.get_type_id().into());
         let sensor_name_str = core::str::from_utf8(&sensor_name_bytes).unwrap_or_default();
 
         json!({
-            "id" : self.get_id(),
+            "id" : sensor_id,
             "type" : sensor_name_str,
             "calibration_offset": self.special_config.calibration_offset
         })

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -422,6 +422,10 @@ impl DataLogger {
                 // TODO: hibernate until the requested wake time
             }
             DataLoggerMode::SDI12 => {
+
+                static mut total_measurements : usize = 0;
+                static mut data: [f64; 36] = [0_f64; 36];
+
                 
                 let mut take_measurement = false;
                 if let Some(sdi12_service) = &mut self.sdi12_service {
@@ -439,53 +443,80 @@ impl DataLogger {
 
                                     Sdi12Command::Mc(digit) => {
                                         if digit == '0' {
-                                            let mut total_measurements: usize = 0;
+                                            let mut total_measurements_count = 0;
 
                                             for i in 0 .. self.sensor_drivers.len() {
                                                 if let Some(ref mut driver) = self.sensor_drivers[i] {
-                                                    total_measurements = total_measurements + driver.get_measured_parameter_count();
+                                                    let driver_measurements = driver.get_measured_parameter_count();
+                                                    total_measurements_count = total_measurements_count + driver_measurements;
                                                 }
                                             }
 
-                                            let measurements_in_payload = if total_measurements > 9 { 9 } else { total_measurements as u8 };
 
-                                            let measurement_time = 2; // 2 seconds approximate for now
-                                            sdi12_service.send_MAck(board, '0', measurement_time, measurements_in_payload);
+                                            let measurement_time = 5; // 5 seconds approximate for now
+                                            sdi12_service.send_MAck(board, '0', measurement_time, total_measurements_count as u8);
+                                            unsafe { total_measurements = total_measurements_count }; // TODO: state var
                                             take_measurement = true;
+                                            board.usb_serial_send(format_args!("SDI12: sleep\n"));
+                                            sdi12_service.sleep(); // this sensor doesn't have readings immediately available.
                                         }
                                         defmt::println!("Sent Ack to M");
                                     }
 
                                     Sdi12Command::D(digit) => {
                                        
+                                        // if digit == '0' {
+                                            // defmt::println!("Build data");
+                                            // let mut total_measurements: usize = 0;
+                                            // let mut data: [f64; 9] = [0_f64; 9];
+                                            // for i in 0 .. self.sensor_drivers.len() {
+                                            //     if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                            //         total_measurements = total_measurements + driver.get_measured_parameter_count();
+                                            //     }
+                                            // }
 
-                                        if digit == '0' {
-                                            let mut total_measurements: usize = 0;
-                                            let mut data: [f64; 9] = [0_f64; 9];
-                                            for i in 0 .. self.sensor_drivers.len() {
-                                                if let Some(ref mut driver) = self.sensor_drivers[i] {
-                                                    total_measurements = total_measurements + driver.get_measured_parameter_count();
-                                                }
-                                            }
+                                            // let measurements_in_payload: u8 = if total_measurements > 9 { 9 } else { total_measurements as u8 };
+                                            // defmt::println!("Build data");
 
-                                            let measurements_in_payload: u8 = if total_measurements > 9 { 9 } else { total_measurements as u8 };
-                                            
-                                            let measurement_index = 0;
-                                            for i in 0 .. self.sensor_drivers.len() {
-                                                if let Some(ref mut driver) = self.sensor_drivers[i] {
-                                                    for j in 0..driver.get_measured_parameter_count() {
-                                                        data[measurement_index] = match driver.get_measured_parameter_value(j) {
-                                                            Ok(value) => value,
-                                                            Err(_) => f64::MAX,
-                                                        }
-                                                    }
-                                                }
+                                            // let mut measurement_index = 0;
+                                            // 'outer: for i in 0 .. self.sensor_drivers.len() {
+                                            //     if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                            //         for j in 0..driver.get_measured_parameter_count() {
+                                            //             data[measurement_index] = match driver.get_measured_parameter_value(j) {
+                                            //                 Ok(value) => value,
+                                            //                 Err(_) => f64::MAX,
+                                            //             };
+                                            //             measurement_index = measurement_index + 1;
+                                            //             if measurement_index >= measurements_in_payload as usize {
+                                            //                 break 'outer;
+                                            //             }
+                                            //         }
+                                            //     }
+                                            // }
+                                            let measurements_in_payload = 4;
+                                            let mut data_send: [f64; 9] = [f64::MAX;9];
+
+                                            let index = digit.to_digit(10);
+                                            if index.is_none() {
+                                                defmt::println!("parse error");
+                                                return;
+                                                //TODO: best way to handle this?
+                                            }
+                                            let index = index.unwrap() as usize;
+                                            defmt::println!("index {}", index);
+
+                                            let start = index * measurements_in_payload;
+                                            let end = start + measurements_in_payload;
+                                            for i in start..end {
+                                                unsafe { data_send[i-start] = data[i]; }
                                             }
                                             
-                                            sdi12_service.send_data(board, '0', data, measurements_in_payload);
+                                            defmt::println!("Data ready");
+                                            sdi12_service.send_data(board, '0', data_send, measurements_in_payload as u8);
+                                            defmt::println!("Sent data");
+                                            board.usb_serial_send(format_args!("SDI12: sleep\n"));
                                             sdi12_service.sleep();
-                                        }
-                                        defmt::println!("Sent data");
+                                        // }
                                     }
                                 }
                             }
@@ -504,7 +535,32 @@ impl DataLogger {
                 }
 
                 if take_measurement {
+                    board.usb_serial_send(format_args!("SDI12: taking measurement\n"));
+
                     self.measure_sensor_values(board);
+
+                
+                    // let measurements_in_payload: u8 = if total_measurements > 9 { 9 } else { total_measurements as u8 };
+                    // defmt::println!("Build data");
+
+                    unsafe { data = [f64::MAX; 36]; }
+
+                    let mut measurement_index = 0;
+                    for i in 0 .. self.sensor_drivers.len() {
+                        if let Some(ref mut driver) = self.sensor_drivers[i] {
+                            for j in 0..driver.get_measured_parameter_count() {
+                                unsafe { 
+                                    data[measurement_index] = match driver.get_measured_parameter_value(j) {
+                                        Ok(value) => value,
+                                        Err(_) => f64::MAX,
+                                    };
+                                }
+                                measurement_index = measurement_index + 1;
+                            }
+                        }
+                    }
+
+                    board.usb_serial_send(format_args!("SDI12: measurement ready\n"));
                 }
             }
         }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -20,6 +20,7 @@ use crate::datalogger::error::hardware_error_text;
 use crate::datalogger::helper;
 use crate::datalogger::modes::DataLoggerMode;
 use crate::datalogger::modes::DataLoggerSerialTxMode;
+use crate::services::sdi12_service::Sdi12Command;
 use crate::{protocol::responses, services::*, telemetry::telemeters::{Telemeter}};
 use alloc::boxed::Box;
 
@@ -51,6 +52,7 @@ pub struct DataLogger {
     lorawan_telemeter: Option<telemetry::telemeters::lorawan::RakWireless3172>,
     modbus_telemeter: Option<telemetry::telemeters::modbus::ModBusRTU>,
     modbus_service: Option<modbus_service::ModbusByteProcessor>,
+    sdi12_service: Option<sdi12_service::Sdi12ByteProcessor>,
 
     // measurement cycle
     completed_bursts: u8,
@@ -74,7 +76,8 @@ impl DataLogger {
             modbus_telemeter: None,
             completed_bursts: 0,
             readings_completed_in_current_burst: 0,
-            modbus_service: None
+            modbus_service: None,
+            sdi12_service: None,
         }
     }
 
@@ -135,6 +138,9 @@ impl DataLogger {
         usart_service::setup(board);
         self.modbus_service = Some(modbus_service::ModbusByteProcessor::new());
         modbus_service::setup(board);
+
+        let sdi12_gpio = 5;
+        self.sdi12_service = Some(sdi12_service::Sdi12ByteProcessor::new(sdi12_gpio));
 
         // read all the sensors from EEPROM
         let registry = get_registry();
@@ -412,6 +418,41 @@ impl DataLogger {
                 // this block is processed when we start up, don't get an interactive mode interrupt, and are in HibernateUntil mode
                 // or when we have just entered this mode
                 // TODO: hibernate until the requested wake time
+            }
+            DataLoggerMode::SDI12 => {
+                if let Some(sdi12_service) = &mut self.sdi12_service {
+                    if sdi12_service.is_awake() == false {
+                        sdi12_service.wake_up(board);
+                    }
+
+                    if sdi12_service.is_awake() {
+                        match sdi12_service.take_message('0', board) {
+                            Ok(mode) => {
+                                match mode {
+                                    Sdi12Command::M => {
+                                    }
+
+                                    Sdi12Command::Mc(digit) => {
+                                        if digit == '0' {
+                                            sdi12_service.send_MAck(board, '0', 0, 2);
+                                        }
+                                    }
+
+                                    Sdi12Command::D(digit) => {
+                                        let mut data: [f64; 9] = [0_f64; 9];
+                                        if digit == '0' {
+                                            data[0] = 1_f64;
+                                            data[1] = 3.14;
+                                            sdi12_service.send_data(board, '0', data, 2);
+                                            sdi12_service.sleep();
+                                        }
+                                    }
+                                }
+                            }
+                            Err(message) => responses::send_command_response_error(board, message, ""),
+                        }
+                    }
+                }
             }
         }
     }
@@ -772,6 +813,10 @@ impl DataLogger {
                         self.mode = DataLoggerMode::Field;
                         // switching into field mode should create a new file
                         self.write_column_headers_to_storage(board);
+                        persist = true;
+                    }
+                    "sdi12" => {
+                        self.mode = DataLoggerMode::SDI12;
                         persist = true;
                     }
                     _ => {
@@ -1321,6 +1366,15 @@ impl DataLogger {
             }
         }
 
+        // if let Some(enable_sdi12) = &values.enable_sdi12 {
+        //     if self.settings.toggles.enable_sdi12() != *enable_sdi12 {
+        //        match self.set_up_modbus_rtu(*enable_sdi12) {
+        //             Ok(_) => {},
+        //             Err(error) => {return Err(error);}, 
+        //         }
+        //     }
+        // }
+
         let new_settings: DataloggerSettings = self.settings.with_values(values);
         let mut old_settings: DataloggerSettings = self.settings.clone();
         self.settings = new_settings;
@@ -1376,7 +1430,8 @@ impl DataLogger {
            "mode" : datalogger::modes::mode_text(&self.mode),
            "interactive_logging": self.settings.toggles.enable_interactive_logging(),
            "enable_lorawan_telemetry" : self.settings.toggles.enable_lorawan_telemetry(),
-           "enable_modbus_rtu" : self.settings.toggles.enable_modbus_rtu()
+           "enable_modbus_rtu" : self.settings.toggles.enable_modbus_rtu(),
+           "enable_sdi12" : self.settings.toggles.enable_sdi12(),
         })
     }
 

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -426,6 +426,7 @@ impl DataLogger {
                     }
 
                     if sdi12_service.is_awake() {
+                        defmt::println!("board awake!");
                         match sdi12_service.take_message('0', board) {
                             Ok(mode) => {
                                 match mode {
@@ -436,6 +437,7 @@ impl DataLogger {
                                         if digit == '0' {
                                             sdi12_service.send_MAck(board, '0', 0, 2);
                                         }
+                                        defmt::println!("Sent Ack to M");
                                     }
 
                                     Sdi12Command::D(digit) => {
@@ -446,12 +448,19 @@ impl DataLogger {
                                             sdi12_service.send_data(board, '0', data, 2);
                                             sdi12_service.sleep();
                                         }
+                                        defmt::println!("Sent data");
                                     }
                                 }
                             }
                             Err(message) => responses::send_command_response_error(board, message, ""),
                         }
                     }
+                    else {
+                        defmt::println!("board sleeping");
+                    }
+                }
+                else {
+                    defmt::println!("sdi12 service not setup");
                 }
             }
         }
@@ -817,7 +826,10 @@ impl DataLogger {
                     }
                     "sdi12" => {
                         self.mode = DataLoggerMode::SDI12;
+                        self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
+                        board.set_debug(false);
                         persist = true;
+                        defmt::println!("In SDI12 mode!");
                     }
                     _ => {
                         self.mode = DataLoggerMode::Interactive;

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -3,6 +3,7 @@
 mod datalogger;
 mod services;
 
+use core::f64;
 use core::i16::MAX;
 
 use datalogger::commands::*;
@@ -421,6 +422,8 @@ impl DataLogger {
                 // TODO: hibernate until the requested wake time
             }
             DataLoggerMode::SDI12 => {
+                
+                let mut take_measurement = false;
                 if let Some(sdi12_service) = &mut self.sdi12_service {
                     if sdi12_service.is_awake() == false {
                         sdi12_service.wake_up(board);
@@ -436,17 +439,50 @@ impl DataLogger {
 
                                     Sdi12Command::Mc(digit) => {
                                         if digit == '0' {
-                                            sdi12_service.send_MAck(board, '0', 0, 2);
+                                            let mut total_measurements: usize = 0;
+
+                                            for i in 0 .. self.sensor_drivers.len() {
+                                                if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                                    total_measurements = total_measurements + driver.get_measured_parameter_count();
+                                                }
+                                            }
+
+                                            let measurements_in_payload = if total_measurements > 9 { 9 } else { total_measurements as u8 };
+
+                                            let measurement_time = 2; // 2 seconds approximate for now
+                                            sdi12_service.send_MAck(board, '0', measurement_time, measurements_in_payload);
+                                            take_measurement = true;
                                         }
                                         defmt::println!("Sent Ack to M");
                                     }
 
                                     Sdi12Command::D(digit) => {
-                                        let mut data: [f64; 9] = [0_f64; 9];
+                                       
+
                                         if digit == '0' {
-                                            data[0] = 1_f64;
-                                            data[1] = 3.14;
-                                            sdi12_service.send_data(board, '0', data, 2);
+                                            let mut total_measurements: usize = 0;
+                                            let mut data: [f64; 9] = [0_f64; 9];
+                                            for i in 0 .. self.sensor_drivers.len() {
+                                                if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                                    total_measurements = total_measurements + driver.get_measured_parameter_count();
+                                                }
+                                            }
+
+                                            let measurements_in_payload: u8 = if total_measurements > 9 { 9 } else { total_measurements as u8 };
+                                            
+                                            let measurement_index = 0;
+                                            for i in 0 .. self.sensor_drivers.len() {
+                                                if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                                    for j in 0..driver.get_measured_parameter_count() {
+                                                        data[measurement_index] = match driver.get_measured_parameter_value(j) {
+                                                            Ok(value) => value,
+                                                            Err(_) => f64::MAX,
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            
+                                            sdi12_service.send_data(board, '0', data, measurements_in_payload);
                                             sdi12_service.sleep();
                                         }
                                         defmt::println!("Sent data");
@@ -465,6 +501,10 @@ impl DataLogger {
                 }
                 else {
                     defmt::panic!("sdi12 service not setup");
+                }
+
+                if take_measurement {
+                    self.measure_sensor_values(board);
                 }
             }
         }
@@ -749,6 +789,7 @@ impl DataLogger {
                 } else {
                     board.write_log_file(format_args!(","));
                 }
+
 
                 for j in 0..driver.get_measured_parameter_count() {
                     match driver.get_measured_parameter_value(j) {

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -352,6 +352,7 @@ impl DataLogger {
         //
         // Do the measurement cycle
         //
+        // defmt::println!("Current mode: {}", datalogger::modes::mode_text(&self.mode));
 
         match self.mode {
             DataLoggerMode::Interactive => {
@@ -452,15 +453,18 @@ impl DataLogger {
                                     }
                                 }
                             }
-                            Err(message) => responses::send_command_response_error(board, message, ""),
+                            Err(message) => {
+                                defmt::println!("Error: {}", message);
+                                // responses::send_command_response_error(board, message, "")
+                            }
                         }
                     }
-                    else {
-                        defmt::println!("board sleeping");
-                    }
+                    // else {
+                    //     defmt::println!("board sleeping");
+                    // }
                 }
                 else {
-                    defmt::println!("sdi12 service not setup");
+                    defmt::panic!("sdi12 service not setup");
                 }
             }
         }

--- a/src/datalogger/src/registry.rs
+++ b/src/datalogger/src/registry.rs
@@ -17,7 +17,7 @@ const SENSOR_NAMES: [&str; 15] = [
     "ring_temp_sim",
     "groundwater_rtu",
     "mhz9041a",
-    "groundwater_flow_sdi12"
+    "gndwater_sdi12",
 ];
 
 pub fn sensor_type_id_from_name(name: &str) -> Result<u16, ()> {

--- a/src/datalogger/src/registry.rs
+++ b/src/datalogger/src/registry.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use crate::drivers::{ types::{SensorDriver, SensorDriverGeneralConfiguration, SENSOR_SETTINGS_PARTITION_SIZE}};
 
 
-const SENSOR_NAMES: [&str; 14] = [
+const SENSOR_NAMES: [&str; 15] = [
     "no_match",
     "generic_analog",
     "atlas_ec",
@@ -136,7 +136,7 @@ pub fn get_registry() -> [DriverCreateFunctions; 256] {
         crate::drivers::mhz9041a::MHZ9041ADriver,
         crate::drivers::mhz9041a::MHZ9041ADriverSpecialConfiguration
     ));
-    driver_create_functions[13] = Some(driver_create_functions!(
+    driver_create_functions[14] = Some(driver_create_functions!(
         crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12,
         crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12SpecialConfiguration
     ));

--- a/src/datalogger/src/registry.rs
+++ b/src/datalogger/src/registry.rs
@@ -16,7 +16,8 @@ const SENSOR_NAMES: [&str; 14] = [
     "ring_w_mux",
     "ring_temp_sim",
     "groundwater_rtu",
-    "mhz9041a"
+    "mhz9041a",
+    "groundwater_flow_sdi12"
 ];
 
 pub fn sensor_type_id_from_name(name: &str) -> Result<u16, ()> {
@@ -134,6 +135,10 @@ pub fn get_registry() -> [DriverCreateFunctions; 256] {
     driver_create_functions[13] = Some(driver_create_functions!(
         crate::drivers::mhz9041a::MHZ9041ADriver,
         crate::drivers::mhz9041a::MHZ9041ADriverSpecialConfiguration
+    ));
+    driver_create_functions[13] = Some(driver_create_functions!(
+        crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12,
+        crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12SpecialConfiguration
     ));
 
     driver_create_functions

--- a/src/datalogger/src/services/mod.rs
+++ b/src/datalogger/src/services/mod.rs
@@ -3,3 +3,4 @@
 pub mod command_service;
 pub mod usart_service;
 pub mod modbus_service;
+pub mod sdi12_service;

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -8,6 +8,22 @@ pub enum Sdi12Command {
     D(char),
 }
 
+#[allow(non_camel_case_types)]
+pub struct SDI12_MResponse {
+    pub address: char,
+    pub ttt: u32,
+    pub n: u8
+}
+
+#[allow(non_camel_case_types)]
+pub struct SDI12_Dresponse {
+    pub address: char,
+    pub data: [f32; 9],
+    pub count: u8,
+    pub terminate: bool,
+    pub last_d_ind: u8
+}
+
 struct CharBuffer<'a> {
     buffer: &'a mut [char],
     cursor: usize,
@@ -165,6 +181,96 @@ impl<'a> Sdi12ByteProcessor {
         let my_board = Sdi12Board::new(self.gpio, board);
         let mut sdi12 = SDI12::new(my_board);
         sdi12.send_response(resp_buffer);
+    }
+
+    pub fn send_m_command(&mut self, board: &mut dyn RRIVBoard, address: char, id: char) -> SDI12_MResponse {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = address;
+        command[1] = 'M';
+        if id == '\0' {
+            command[2] = '!';
+        }
+        else {
+            command[2] = id;
+            command[3] = '!';
+        }
+        sdi12.send_break();
+        sdi12.send_command(command);
+        defmt::println!("Sent 0M0!");
+        let response = sdi12.read_response();
+        // parse the response
+        // format: <address>tttn<CR><LF>
+        let address_r = response[0];
+        if address_r != address {
+            // invalid response
+            return SDI12_MResponse {
+                address: '\0',
+                ttt: 0,
+                n: 0
+            };
+        }
+
+        let ttt = &response[1..4];
+        // convert ttt from ASCII to integer
+        let mut result: u32 = 0; // Or u32, usize, etc.
+
+        for &c in ttt {
+            // to_digit(10) converts the char to a number from 0-9
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                result = (result * 10) + d as u32;
+            }
+        }
+
+        let n : u8 = response[4].to_digit(10).unwrap_or(0) as u8; // convert ASCII to integer
+
+        // self.sdi12_board.delay_us(SDI12_GAP);
+        
+        SDI12_MResponse {
+            address: address_r,
+            ttt: result,
+            n: n
+        }
+    }
+
+    pub fn send_d0_command(&mut self, board: &mut dyn RRIVBoard, address: char, num_data: u8) -> SDI12_Dresponse {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = address;
+        command[1] = 'D';
+        command[2] = '0';
+        command[3] = '!';
+        let mut resp : SDI12_Dresponse = SDI12_Dresponse {
+            address: '\0',
+            data: [0.0; 9],
+            count: 0,
+            terminate: false,
+            last_d_ind: 0
+        };
+        sdi12.send_command(command);
+        defmt::println!("Sent 0D0!");
+        let response = sdi12.read_response();
+        // parse the response
+        // format: <address><data><CR><LF>
+        let address_r = response[0];
+        if address_r != address {
+            // invalid response
+            return resp;
+        }
+        resp.address = address_r;
+        let response = &response[1..SDI12_BUFFER_SIZE];
+        (resp.data, resp.count) = sdi12.parse_data(response);
+        
+        if resp.count == num_data {
+            resp.terminate = true;
+        }
+        
+        resp
     }
 }
 

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -135,8 +135,6 @@ impl<'a> Sdi12ByteProcessor {
             _ => return Err("Invalid Command"),
         };
 
-        board.delay_ms(10);
-
         Ok(mode)
     }
 

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -74,6 +74,7 @@ impl<'a> BoardForSDI12 for Sdi12Board<'a> {
 
     fn delay_us(&mut self, us: u16) {
         self.board.delay_us(us);
+        self.board.run_loop_iteration(); // TODO: feed the watchdog, need a dedicated call for this though.
     }
 
     fn pin_mode(&mut self, mode: gpio::GpioMode) {
@@ -109,6 +110,9 @@ impl<'a> Sdi12ByteProcessor {
         let my_board = Sdi12Board::new(self.gpio, board);
         let mut sdi12 = SDI12::new(my_board);
         self.awake = sdi12.receive_break();
+        if self.awake {
+            board.usb_serial_send(format_args!("SDI12: received break\n"));
+        }
     }
 
     pub fn is_awake(&mut self) -> bool {
@@ -124,10 +128,14 @@ impl<'a> Sdi12ByteProcessor {
         let mut sdi12 = SDI12::new(my_board);
         let buffer = sdi12.read_command();
         if buffer[0] != address {
+            board.usb_serial_send(format_args!("SDI12: sleep\n"));
             self.sleep();
             defmt::println!("{} != {}", buffer[0], address);
             return Err("Address not matching");
         }
+        
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}\n", buffer[0], buffer[1], buffer[2]));
+
         let mode = match (buffer[1], buffer[2]) {
             ('M', '!') => Sdi12Command::M,
             ('M', d @ '0'..='9') => Sdi12Command::Mc(d),
@@ -153,6 +161,7 @@ impl<'a> Sdi12ByteProcessor {
         let my_board = Sdi12Board::new(self.gpio, board);
         let mut sdi12 = SDI12::new(my_board);
         sdi12.send_response(resp_buffer);
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}\n", resp_buffer[0], resp_buffer[1], resp_buffer[2], resp_buffer[3], resp_buffer[4])); // TODO: if self.watch
     }
 
     pub fn send_data(&mut self, board: &mut dyn RRIVBoard, address: char, data: [f64;9], n: u8) {
@@ -179,6 +188,39 @@ impl<'a> Sdi12ByteProcessor {
         let my_board = Sdi12Board::new(self.gpio, board);
         let mut sdi12 = SDI12::new(my_board);
         sdi12.send_response(resp_buffer);
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\n", 
+            resp_buffer[0], 
+            resp_buffer[1], 
+            resp_buffer[2], 
+            resp_buffer[3], 
+            resp_buffer[4], 
+            resp_buffer[5], 
+            resp_buffer[6], 
+            resp_buffer[7], 
+            resp_buffer[8],
+            resp_buffer[9],
+            resp_buffer[10], 
+            resp_buffer[11], 
+            resp_buffer[12], 
+            resp_buffer[13], 
+            resp_buffer[14], 
+            resp_buffer[15], 
+            resp_buffer[16], 
+            resp_buffer[17], 
+            resp_buffer[18],
+            resp_buffer[19],
+            resp_buffer[20], 
+            resp_buffer[21], 
+            resp_buffer[22], 
+            resp_buffer[23], 
+            resp_buffer[24], 
+            resp_buffer[25], 
+            resp_buffer[26], 
+            resp_buffer[27], 
+            resp_buffer[28],
+            resp_buffer[29]
+        )); // TODO: if self.watch
+
     }
 
     pub fn send_m_command(&mut self, board: &mut dyn RRIVBoard, address: char, id: char) -> SDI12_MResponse {
@@ -198,7 +240,12 @@ impl<'a> Sdi12ByteProcessor {
         sdi12.send_break();
         sdi12.send_command(command);
         defmt::println!("Sent 0M0!");
+
         let response = sdi12.read_response();
+
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}\n", command[0], command[1], command[2], command[3])); // TODO: if self.watch
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}\n", response[0], response[1], response[2], response[3], response[4])); // TODO: if self.watch
+
         // parse the response
         // format: <address>tttn<CR><LF>
         let address_r = response[0];
@@ -250,9 +297,18 @@ impl<'a> Sdi12ByteProcessor {
             terminate: false,
             last_d_ind: 0
         };
+        
+        sdi12.send_break();
         sdi12.send_command(command);
         defmt::println!("Sent 0D0!");
         let response = sdi12.read_response();
+
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}\n", command[0], command[1], command[2], command[3], command[4])); // TODO: if self.watch
+
+
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
         // parse the response
         // format: <address><data><CR><LF>
         let address_r = response[0];
@@ -267,7 +323,40 @@ impl<'a> Sdi12ByteProcessor {
         if resp.count == num_data {
             resp.terminate = true;
         }
-        
+
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\n", 
+            response[0], 
+            response[1], 
+            response[2], 
+            response[3], 
+            response[4], 
+            response[5], 
+            response[6], 
+            response[7], 
+            response[8],
+            response[9],
+            response[10], 
+            response[11], 
+            response[12], 
+            response[13], 
+            response[14], 
+            response[15], 
+            response[16], 
+            response[17], 
+            response[18],
+            response[19],
+            response[20], 
+            response[21], 
+            response[22], 
+            response[23], 
+            response[24], 
+            response[25], 
+            response[26], 
+            response[27], 
+            response[28],
+            response[29]
+        )); // TODO: if self.watch
+
         resp
     }
 }

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -119,22 +119,23 @@ impl<'a> Sdi12ByteProcessor {
             _ => return Err("Invalid Command"),
         };
 
+        board.delay_ms(10);
+
         Ok(mode)
     }
 
     pub fn send_MAck(&mut self, board: &mut dyn RRIVBoard, address: char, ttt: u32, n: u8) {
         let mut resp_buffer: [char; SDI12_BUFFER_SIZE] = ['0'; SDI12_BUFFER_SIZE];
         resp_buffer[0] = address;
-        let mut t = ttt;
-        let mut i = 1;
-        while t > 0 {
-            resp_buffer[i] = ((t % 10) as u8) as char;
-            t = t / 10;
-            i += 1;
-        }
-        resp_buffer[i] = n as char;
-        resp_buffer[i+1] = '\r';
-        resp_buffer[i+2] = '\n';
+
+        resp_buffer[1] = (b'0' + ((ttt / 100) % 10) as u8) as char; // Hundreds
+        resp_buffer[2] = (b'0' + ((ttt / 10) % 10) as u8) as char;  // Tens
+        resp_buffer[3] = (b'0' + (ttt % 10) as u8) as char;         // Ones
+
+        resp_buffer[4] = (b'0' + n) as char;            
+
+        resp_buffer[5] = '\r';
+        resp_buffer[6] = '\n';
         let my_board = Sdi12Board::new(self.gpio, board);
         let mut sdi12 = SDI12::new(my_board);
         sdi12.send_response(resp_buffer);

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -1,0 +1,170 @@
+use rriv_board::{RRIVBoard, gpio};
+use sdi12::*;
+use core::fmt::{self, Write};
+
+pub enum Sdi12Command {
+    M,
+    Mc(char),
+    D(char),
+}
+
+struct CharBuffer<'a> {
+    buffer: &'a mut [char],
+    cursor: usize,
+}
+
+impl<'a> Write for CharBuffer<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            if self.cursor < self.buffer.len() {
+                self.buffer[self.cursor] = c;
+                self.cursor += 1;
+            } else {
+                // Return an error if we run out of space in the array
+                return Err(fmt::Error); 
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct Sdi12Board <'a> {
+    gpio: u8,
+    board: &'a mut dyn RRIVBoard
+}
+
+impl<'a> Sdi12Board<'a> {
+    pub fn new(gpio: u8, board: &'a mut dyn RRIVBoard) -> Self {
+        Sdi12Board {
+            gpio,
+            board
+        }
+    }
+}
+
+impl<'a> BoardForSDI12 for Sdi12Board<'a> {
+    fn write(&mut self, value: bool) {
+        self.board.write_gpio_pin(self.gpio, value);
+    }
+
+    fn read(&mut self) -> bool {
+        let result = self.board.read_gpio_pin(self.gpio);
+        let value = match result {
+            Ok(value) => value,
+            Err(_) => false
+        };
+        value
+    }
+
+    fn delay_us(&mut self, us: u16) {
+        self.board.delay_us(us);
+    }
+
+    fn pin_mode(&mut self, mode: gpio::GpioMode) {
+        self.board.set_gpio_pin_mode(self.gpio, mode);
+    }
+
+    fn millis(&mut self) -> u32 {
+        self.board.millis()
+    }
+}
+
+
+
+pub fn setup(board: &mut dyn RRIVBoard) {
+    // not implemented, does nothing.  
+    // see notes below
+}
+
+pub struct Sdi12ByteProcessor {
+    gpio: u8,
+    awake: bool,
+}
+
+impl<'a> Sdi12ByteProcessor {
+    pub fn new(gpio: u8) -> Sdi12ByteProcessor {
+        Sdi12ByteProcessor {
+            gpio: gpio,
+            awake: false
+        }
+    }
+
+    pub fn wake_up(&mut self, board: &mut dyn RRIVBoard) {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        self.awake = sdi12.receive_break();
+    }
+
+    pub fn is_awake(&mut self) -> bool {
+        self.awake
+    }
+
+    pub fn sleep(&mut self) {
+        self.awake = false;
+    }
+
+    pub fn take_message(&mut self, address: char, board: &mut dyn RRIVBoard) -> Result<Sdi12Command, &str> {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        let buffer = sdi12.read_command();
+        if buffer[0] != address {
+            return Err("Address not matching");
+        }
+        let mode = match (buffer[1], buffer[2]) {
+            ('M', '!') => Sdi12Command::M,
+            ('M', d @ '0'..='9') => Sdi12Command::Mc(d),
+            ('D', d @ '0'..='9') => Sdi12Command::D(d),
+            _ => return Err("Invalid Command"),
+        };
+
+        Ok(mode)
+    }
+
+    pub fn send_MAck(&mut self, board: &mut dyn RRIVBoard, address: char, ttt: u32, n: u8) {
+        let mut resp_buffer: [char; SDI12_BUFFER_SIZE] = ['0'; SDI12_BUFFER_SIZE];
+        resp_buffer[0] = address;
+        let mut t = ttt;
+        let mut i = 1;
+        while t > 0 {
+            resp_buffer[i] = ((t % 10) as u8) as char;
+            t = t / 10;
+            i += 1;
+        }
+        resp_buffer[i] = n as char;
+        resp_buffer[i+1] = '\r';
+        resp_buffer[i+2] = '\n';
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        sdi12.send_response(resp_buffer);
+    }
+
+    pub fn send_data(&mut self, board: &mut dyn RRIVBoard, address: char, data: [f64;9], n: u8) {
+        let mut resp_buffer: [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
+
+        let mut writer = CharBuffer {
+            buffer: &mut resp_buffer,
+            cursor: 0,
+        };
+
+        let _ = write!(writer, "{}", address);
+
+        let mut i = 0;
+        for &value in &data {
+            let _ = write!(writer, "{:+.2}", value);
+            i += 1;
+            if i == n {
+                break;
+            }
+        }
+
+        // End with <CR><LF>
+        let _ = write!(writer, "\r\n");
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        sdi12.send_response(resp_buffer);
+    }
+}
+
+
+
+

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -108,6 +108,8 @@ impl<'a> Sdi12ByteProcessor {
         let mut sdi12 = SDI12::new(my_board);
         let buffer = sdi12.read_command();
         if buffer[0] != address {
+            self.sleep();
+            defmt::println!("{} != {}", buffer[0], address);
             return Err("Address not matching");
         }
         let mode = match (buffer[1], buffer[2]) {

--- a/src/sdi12/Cargo.toml
+++ b/src/sdi12/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sdi-12"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+format_no_std = "1.2.0"
+rtt-target = { version = "0.6.1", features =  ["defmt"] }
+defmt = "1.0.1"
+

--- a/src/sdi12/Cargo.toml
+++ b/src/sdi12/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sdi-12"
+name = "sdi12"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,4 +7,5 @@ edition = "2021"
 format_no_std = "1.2.0"
 rtt-target = { version = "0.6.1", features =  ["defmt"] }
 defmt = "1.0.1"
+rriv_board = { path = "../../board/rriv_board" } 
 

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -1,0 +1,16 @@
+
+
+
+pub trait digital_pin {
+    pub fn write(value);
+    pub fn read() -> bool;
+}
+
+pub trait delay_us {
+    pub fn delay(ms: u32);
+}
+
+
+pub fn send_command(&str, &mut impl digital_pin, &mut impl delay_us) -> [u8;100] {
+    // sdi-12 implementation
+}

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -153,13 +153,26 @@ impl<B> SDI12<B> where B: BoardForSDI12,
     }
 
     pub fn read_char(&mut self) -> Option<char> {
+        let mut iter_count = 0;
 
         while self.sdi12_board.read() == false {
-            let elapsed_time = self.sdi12_board.millis().wrapping_sub(self.timeout_counter);
-            if elapsed_time > SDI12_TIMEOUT {
-                return None; // SDI12_timeout
+            // let millis = self.sdi12_board.millis();
+            // let elapsed: i32 = millis as i32 - self.timeout_counter as i32;
+            // let mut new_elapsed: u32 = elapsed as u32;
+            // if elapsed < 0 {
+            //     new_elapsed = 65535 - self.timeout_counter + millis;
+            // }
+            // defmt::println!("millis {}, elapsed time: {}, timeout: {}", millis, new_elapsed, self.timeout_counter);
+            // if new_elapsed as u32 > SDI12_TIMEOUT {
+            //     return None; // SDI12_timeout
+            // }
+            if iter_count > 100 {
+                return None;
             }
+            iter_count += 1;
+            self.sdi12_board.delay_us(1000);
         }
+        defmt::println!("detected a start bit");
         self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT / 2);
 
         if self.sdi12_board.read() == false {

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -7,6 +7,7 @@ const SDI12_BREAK_DURATION_US: u16 = 12000;
 const SDI12_MARK_DURATION_US: u16 = 8333;
 const SDI12_TICKS_PER_BIT: u16 = 8333; // 1 bit duration at 1200 baud
 // const SDI12_TIMEOUT : u32 = 100; // timeout for reading response in milliseconds
+pub const SDI12_GAP: u16 = 10000;
 pub const SDI12_BUFFER_SIZE: usize = 100; // size of the buffer for reading responses
 pub const SDI12_COMMAND_SIZE: usize = 10;
 
@@ -87,7 +88,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
         
         // Hold it HIGH for 12 ms
         self.sdi12_board.write(true);
-        self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US + TIMING_TOLERANCE);
+        self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US);
         
         // Marking by holding it LOW for 8.33 ms
         self.sdi12_board.write(false);
@@ -154,7 +155,6 @@ impl<B> SDI12<B> where B: BoardForSDI12,
 
     pub fn read_char(&mut self) -> Option<char> {
         let mut iter_count = 0;
-
         while self.sdi12_board.read() == false {
             // let millis = self.sdi12_board.millis();
             // let elapsed: i32 = millis as i32 - self.timeout_counter as i32;
@@ -257,7 +257,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             if *c == '\n' {
                 break; // stop at termination character
             }
-            self.sdi12_board.delay_us(10000);
+            self.sdi12_board.delay_us(SDI12_GAP);
         }
         self.set_state(SDIPinState::Sdi12Listening);
     }
@@ -300,6 +300,8 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             command[2] = id;
             command[3] = '!';
         }
+        self.send_break();
+        self.sdi12_board.delay_us(SDI12_GAP);
         self.send_command(command);
         defmt::println!("Sent 0M0!");
         let response = self.read_response();
@@ -329,7 +331,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
 
         let n : u8 = response[4].to_digit(10).unwrap_or(0) as u8; // convert ASCII to integer
 
-        self.sdi12_board.delay_us(10000);
+        self.sdi12_board.delay_us(SDI12_GAP);
         
         SDI12_MResponse {
             address: address_r,
@@ -402,7 +404,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
 
         resp.count = count as u8;
         
-        self.sdi12_board.delay_us(10000);
+        self.sdi12_board.delay_us(SDI12_GAP);
 
         resp
     }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -1,16 +1,375 @@
+#![no_std]
 
+use rriv_board::gpio;
 
+const TIMING_TOLERANCE: u16 = 1000;
+const SDI12_BREAK_DURATION_US: u16 = 12000 + TIMING_TOLERANCE;
+const SDI12_MARK_DURATION_US: u16 = 8333;
+const SDI12_TICKS_PER_BIT: u16 = 8333; // 1 bit duration at 1200 baud
+const SDI12_TIMEOUT : u32 = 1000; // timeout for reading response in milliseconds
+pub const SDI12_BUFFER_SIZE: usize = 100; // size of the buffer for reading responses
+pub const SDI12_COMMAND_SIZE: usize = 10;
 
-pub trait digital_pin {
-    pub fn write(value);
-    pub fn read() -> bool;
+pub enum SDIPinState {
+    Sdi12Disabled,         // SDI-12 is disabled, pin mode INPUT, interrupts disabled for the pin
+    Sdi12Enabled,          // SDI-12 is enabled, pin mode INPUT, interrupts disabled for the pin 
+    Sdi12Holding,          // The line is being held LOW, pin mode OUTPUT, interrupts disabled for the pin
+    Sdi12Transmitting,     // Data is being transmitted by the SDI-12 master, pin mode OUTPUT, interrupts disabled for the pin
+    Sdi12Listening         // The SDI-12 master is listening for a response from the slave, pin mode INPUT, interrupts enabled for the pin
 }
 
-pub trait delay_us {
-    pub fn delay(ms: u32);
+pub trait BoardForSDI12 {
+    fn write(&mut self, value: bool);
+    fn read(&mut self) -> bool;
+    fn delay_us(&mut self, us: u16);
+    fn pin_mode(&mut self, mode: gpio::GpioMode);
+    fn millis(&mut self) -> u32;
 }
 
+#[allow(non_camel_case_types)]
+pub struct SDI12_MResponse {
+    pub address: char,
+    pub ttt: u32,
+    pub n: u8
+}
 
-pub fn send_command(&str, &mut impl digital_pin, &mut impl delay_us) -> [u8;100] {
-    // sdi-12 implementation
+#[allow(non_camel_case_types)]
+pub struct SDI12_Dresponse {
+    pub address: char,
+    pub data: [f32; 9],
+    pub count: u8,
+    pub terminate: bool,
+    pub last_d_ind: u8
+}
+
+pub struct SDI12 <B> {
+    state: SDIPinState,
+    sdi12_board: B,
+    timeout_counter: u32
+}
+
+impl<B> SDI12<B> where B: BoardForSDI12,
+{
+    pub fn new(sdi12_board: B) -> Self
+    {
+        SDI12 {
+            state: SDIPinState::Sdi12Enabled,
+            sdi12_board: sdi12_board,
+            timeout_counter: 0
+        }
+    }
+
+    pub fn set_state(&mut self, state: SDIPinState) {
+        // set the digital pin to the specified value
+        self.state = state;
+        match self.state {
+            SDIPinState::Sdi12Transmitting => {
+                // set pin mode to OUTPUT
+                self.sdi12_board.pin_mode(gpio::GpioMode::PushPullOutput);
+            },
+            SDIPinState::Sdi12Listening => {
+                // set pin mode to INPUT
+                self.sdi12_board.pin_mode(gpio::GpioMode::FloatingInput);
+            }
+            _ => {
+                // For SDI12_HOLDING, SDI12_DISABLED and SDI12_ENABLED, set pin mode to INPUT
+                self.sdi12_board.pin_mode(gpio::GpioMode::FloatingInput);
+            }
+        }
+    }
+
+    pub fn send_break(&mut self) {
+
+        self.set_state(SDIPinState::Sdi12Transmitting);
+        
+        // Hold it HIGH for 12 ms
+        self.sdi12_board.write(true);
+        self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US);
+        
+        // Marking by holding it LOW for 8.33 ms
+        self.sdi12_board.write(false);
+        self.sdi12_board.delay_us(SDI12_MARK_DURATION_US);
+    }
+
+    pub fn receive_break(&mut self) -> bool {
+        self.set_state(SDIPinState::Sdi12Listening);
+        let mut is_valid_break = true;
+        if self.sdi12_board.read() == true {
+            // check after every 1ms for 12 times to see if it is a valid break
+            for _ in 0..12 {
+                self.sdi12_board.delay_us(1000); // Wait 1ms
+                
+                if self.sdi12_board.read() == false {
+                    is_valid_break = false;
+                    break;
+                }
+            }
+            if is_valid_break {
+                // wait for the line to drop LOW
+                while self.sdi12_board.read() == true {}
+            }
+        }
+        is_valid_break
+    }
+
+    pub fn write_char(&mut self, c: char) {
+        // sdi-12 write character implementation
+        // convert char to byte and write it bit by bit, LSB first, with a start bit and a stop bit
+        let mut byte = c as u8;
+        let parity = parity_bit(byte);
+        byte |= (parity as u8) << 7;    // add parity bit as the most significant bit
+
+        // start bit
+        self.sdi12_board.write(true);
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+        // data bits
+        for i in 0..8 {
+            let bit = (byte >> i) & 1;
+            self.sdi12_board.write(bit == 0);
+            self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+        }
+        // stop bit
+        self.sdi12_board.write(false);
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+    }
+
+    pub fn read_char(&mut self) -> Option<char> {
+
+        while self.sdi12_board.read() == false {
+            if self.sdi12_board.millis() - self.timeout_counter > SDI12_TIMEOUT {
+                return None; // SDI12_timeout
+            }
+        }
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT / 2);
+
+        if self.sdi12_board.read() == false {
+            return None; 
+        }
+
+        let mut byte: u8 = 0;
+
+        for i in 0..8 {
+            self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+            let bit_value = match self.sdi12_board.read() {
+                true => 0,
+                false => 1
+            };
+            byte |= bit_value << i;
+        }
+
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+        let stop_bit = self.sdi12_board.read();
+
+        if stop_bit {
+            return None;
+        }
+
+        let character_data = byte & 0x7F;
+
+        // Verify the parity bit here before returning)
+        let parity_bit_received = (byte >> 7) & 1 == 1;
+        let parity_bit_calculated = parity_bit(character_data);
+        if parity_bit_received != parity_bit_calculated {
+            return None;
+        }
+
+        Some(character_data as char)
+    }
+
+    pub fn send_command(&mut self, command: [char; SDI12_COMMAND_SIZE]) {
+        // sdi-12 implementation
+        self.send_break();
+        for c in command.iter() {
+            self.write_char(*c);
+            if *c == '!' {
+                break; // stop at termination character
+            }
+        }
+        self.set_state(SDIPinState::Sdi12Listening);
+    }
+
+    pub fn read_command(&mut self) -> [char; SDI12_COMMAND_SIZE] {
+        self.set_state(SDIPinState::Sdi12Listening);
+        let mut buffer: [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        let mut bytes_read = 0;
+
+        while bytes_read < SDI12_COMMAND_SIZE {
+            self.timeout_counter = self.sdi12_board.millis();
+            match self.read_char() {
+                Some(byte) => {
+                    // store the byte in the response buffer
+                    buffer[bytes_read] = byte;
+                    bytes_read += 1;
+                    if byte == '!' {
+                        break;
+                    }
+                },
+                None => {
+                    break; // SDI12_timeout or error
+                }
+            }
+        }
+
+        buffer
+    }
+
+    pub fn send_response(&mut self, data: [char; SDI12_BUFFER_SIZE]) {
+        self.set_state(SDIPinState::Sdi12Transmitting);
+        for c in data.iter() {
+            self.write_char(*c);
+            if *c == '\n' {
+                break; // stop at termination character
+            }
+        }
+        self.set_state(SDIPinState::Sdi12Listening);
+    }
+
+    pub fn read_response(&mut self) -> [char; SDI12_BUFFER_SIZE] {
+        // sdi-12 implementation
+        self.set_state(SDIPinState::Sdi12Listening);
+        let mut buffer: [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
+        let mut bytes_read = 0;
+        while bytes_read < SDI12_BUFFER_SIZE {
+            self.timeout_counter = self.sdi12_board.millis();
+            match self.read_char() {
+                Some(byte) => {
+                    // store the byte in the response buffer
+                    buffer[bytes_read] = byte;
+                    bytes_read += 1;
+                    if byte == '\n' {
+                        break;
+                    }
+                },
+                None => {
+                    break; // SDI12_timeout or error
+                }
+            }
+        }
+        buffer
+    }
+
+    pub fn send_m_command(&mut self, address: char, id: char) -> SDI12_MResponse {
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = address;
+        command[1] = 'M';
+        if id == '\0' {
+            command[2] = '!';
+        }
+        else {
+            command[2] = id;
+            command[3] = '!';
+        }
+        self.send_command(command);
+        let response = self.read_response();
+        // parse the response
+        // format: <address>tttn<CR><LF>
+        let address_r = response[0];
+        if address_r != address {
+            // invalid response
+            return SDI12_MResponse {
+                address: '\0',
+                ttt: 0,
+                n: 0
+            };
+        }
+
+        let ttt = &response[1..4];
+        // convert ttt from ASCII to integer
+        let mut result: u32 = 0; // Or u32, usize, etc.
+
+        for &c in ttt {
+            // to_digit(10) converts the char to a number from 0-9
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                result = (result * 10) + d as u32;
+            }
+        }
+
+        let n : u8 = response[4].to_digit(10).unwrap_or(0) as u8; // convert ASCII to integer
+        
+        SDI12_MResponse {
+            address: address_r,
+            ttt: result,
+            n: n
+        }
+    }
+
+    pub fn send_d0_command(&mut self, address: char, num_data: u8) -> SDI12_Dresponse {
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = address;
+        command[1] = 'D';
+        command[2] = '0';
+        command[3] = '!';
+        let mut resp : SDI12_Dresponse = SDI12_Dresponse {
+            address: '\0',
+            data: [0.0; 9],
+            count: 0,
+            terminate: false,
+            last_d_ind: 0
+        };
+        self.send_command(command);
+        let response = self.read_response();
+        // parse the response
+        // format: <address><data><CR><LF>
+        let address_r = response[0];
+        if address_r != address {
+            // invalid response
+            return resp;
+        }
+        resp.address = address_r;
+        let response = &response[1..SDI12_BUFFER_SIZE];
+        let mut count = 0;
+        let mut temp_buf = [0u8; 16]; 
+        let mut temp_len = 0;
+
+        for &c in response {
+            if c == '+' || c == '-' || c == '\r' || c == '\n' {
+                if temp_len > 0 {
+                    // Convert to a string slice
+                    if let Ok(s) = core::str::from_utf8(&temp_buf[..temp_len]) {
+                        // Parse the float
+                        if let Ok(val) = s.parse::<f32>() {
+                            resp.data[count] = val;
+                            count += 1;
+                        }
+                    }
+                }
+                temp_len = 0;
+                if c == '\r' || c == '\n' {
+                    break;
+                }
+                
+                if c == '+' || c == '-' {
+                    temp_buf[0] = c as u8;
+                    temp_len = 1;
+                }
+                
+            } 
+            else if c.is_ascii() && temp_len < temp_buf.len() {
+                temp_buf[temp_len] = c as u8;
+                temp_len += 1;
+            }
+        }
+        
+        if count == num_data as usize {
+            resp.terminate = true;
+        }
+
+        resp.count = count as u8;
+
+        resp
+    }
+
+}
+
+// Helper functions
+pub fn parity_bit(byte: u8) -> bool {
+    // returns the parity bit for the given byte, true for odd parity, false for even parity
+    let mut count = 0;
+    for i in 0..8 {
+        if (byte >> i) & 1 == 1 {
+            count += 1;
+        }
+    }
+    count % 2 == 1
 }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -136,7 +136,8 @@ impl<B> SDI12<B> where B: BoardForSDI12,
     pub fn read_char(&mut self) -> Option<char> {
 
         while self.sdi12_board.read() == false {
-            if self.sdi12_board.millis() - self.timeout_counter > SDI12_TIMEOUT {
+            let elapsed_time = self.sdi12_board.millis().wrapping_sub(self.timeout_counter);
+            if elapsed_time > SDI12_TIMEOUT {
                 return None; // SDI12_timeout
             }
         }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -2,12 +2,12 @@
 
 use rriv_board::gpio;
 
-const TIMING_TOLERANCE: u16 = 400;
+const SDI12_TIMING_TOLERANCE: u16 = 400;
 const SDI12_BREAK_DURATION_US: u16 = 12000;
 const SDI12_MARK_DURATION_US: u16 = 8333;
 const SDI12_TICKS_PER_BIT: u16 = 8333; // 1 bit duration at 1200 baud
 // const SDI12_TIMEOUT : u32 = 100; // timeout for reading response in milliseconds
-pub const SDI12_GAP: u16 = 10000;
+const SDI12_GAP: u16 = 5000;
 pub const SDI12_BUFFER_SIZE: usize = 100; // size of the buffer for reading responses
 pub const SDI12_COMMAND_SIZE: usize = 10;
 
@@ -98,17 +98,17 @@ impl<B> SDI12<B> where B: BoardForSDI12,
     pub fn receive_break(&mut self) -> bool {   
         self.set_state(SDIPinState::Sdi12Listening);
         if self.sdi12_board.read() == true {
-            defmt::println!("Start for 12ms");
-            self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US - TIMING_TOLERANCE);
+            // defmt::println!("Start for 12ms");
+            self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US - SDI12_TIMING_TOLERANCE);
             let mut iter_count = 0;
             while self.sdi12_board.read() {
-                defmt::println!("iter_count: {}", iter_count);
+                // defmt::println!("iter_count: {}", iter_count);
                 if iter_count > 10 {
                     defmt::println!("Timeout! line is not falling low");
                     return false;
                 }
                 iter_count += 1;
-                self.sdi12_board.delay_us(TIMING_TOLERANCE);
+                self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
             }
             // // check after every 1ms for 12 times to see if it is a valid break
             // for _ in 0..12 {
@@ -127,16 +127,16 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             //         defmt::println!("Timeout! line is not falling low");
             //         return false;
             //     }
-            //     self.sdi12_board.delay_us(TIMING_TOLERANCE);
+            //     self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
             //     iter_count += 1;
             // }
-            self.sdi12_board.delay_us(SDI12_MARK_DURATION_US - 2 * TIMING_TOLERANCE);
+            self.sdi12_board.delay_us(SDI12_MARK_DURATION_US - 2 * SDI12_TIMING_TOLERANCE);
             if self.sdi12_board.read() {
                 defmt::println!("Invalid marking");
                 return false;
             }
-            self.sdi12_board.delay_us(TIMING_TOLERANCE);
-            defmt::println!("Valid marking");
+            self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
+            // defmt::println!("Valid marking");
             // for _ in 0..8 {
             //     self.sdi12_board.delay_us(1000);
             //     if self.sdi12_board.read() {
@@ -144,7 +144,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             //         return false;
             //     }
             // }
-            self.sdi12_board.delay_us(TIMING_TOLERANCE);
+            self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
             return true;
         }
         return false;
@@ -235,7 +235,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             if *c == '!' {
                 break; // stop at termination character
             }
-            self.sdi12_board.delay_us(SDI12_GAP);
+            // self.sdi12_board.delay_us(SDI12_GAP);
         }
         self.set_state(SDIPinState::Sdi12Listening);
     }
@@ -263,6 +263,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                 }
             }
         }
+        self.sdi12_board.delay_us(SDI12_GAP);
 
         buffer
     }
@@ -274,7 +275,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             if *c == '\n' {
                 break; // stop at termination character
             }
-            self.sdi12_board.delay_us(SDI12_GAP);
+            // self.sdi12_board.delay_us(SDI12_GAP);
         }
         self.set_state(SDIPinState::Sdi12Listening);
     }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -99,33 +99,51 @@ impl<B> SDI12<B> where B: BoardForSDI12,
         self.set_state(SDIPinState::Sdi12Listening);
         if self.sdi12_board.read() == true {
             defmt::println!("Start for 12ms");
-            // check after every 1ms for 12 times to see if it is a valid break
-            for _ in 0..12 {
-                self.sdi12_board.delay_us(1000); // Wait 1ms
-                
-                if self.sdi12_board.read() == false {
-                    defmt::println!("Line dropped low before 12ms");
-                    return false;
-                }
-            }
-            defmt::println!("Valid break, waiting...");
-            // wait for the line to drop LOW
+            self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US - TIMING_TOLERANCE);
             let mut iter_count = 0;
-            while self.sdi12_board.read() == true {
-                if iter_count > 1 {
+            while self.sdi12_board.read() {
+                defmt::println!("iter_count: {}", iter_count);
+                if iter_count > 10 {
                     defmt::println!("Timeout! line is not falling low");
                     return false;
                 }
-                self.sdi12_board.delay_us(TIMING_TOLERANCE);
                 iter_count += 1;
+                self.sdi12_board.delay_us(TIMING_TOLERANCE);
             }
-            for _ in 0..8 {
-                self.sdi12_board.delay_us(1000);
-                if self.sdi12_board.read() {
-                    defmt::println!("line went high too early, invalid marking");
-                    return false;
-                }
+            // // check after every 1ms for 12 times to see if it is a valid break
+            // for _ in 0..12 {
+            //     self.sdi12_board.delay_us(1000); // Wait 1ms
+                
+            //     if self.sdi12_board.read() == false {
+            //         defmt::println!("Line dropped low before 12ms");
+            //         return false;
+            //     }
+            // }
+            // defmt::println!("Valid break, waiting...");
+            // // wait for the line to drop LOW
+            // let mut iter_count = 0;
+            // while self.sdi12_board.read() == true {
+            //     if iter_count > 1 {
+            //         defmt::println!("Timeout! line is not falling low");
+            //         return false;
+            //     }
+            //     self.sdi12_board.delay_us(TIMING_TOLERANCE);
+            //     iter_count += 1;
+            // }
+            self.sdi12_board.delay_us(SDI12_MARK_DURATION_US - 2 * TIMING_TOLERANCE);
+            if self.sdi12_board.read() {
+                defmt::println!("Invalid marking");
+                return false;
             }
+            self.sdi12_board.delay_us(TIMING_TOLERANCE);
+            defmt::println!("Valid marking");
+            // for _ in 0..8 {
+            //     self.sdi12_board.delay_us(1000);
+            //     if self.sdi12_board.read() {
+            //         defmt::println!("line went high too early, invalid marking");
+            //         return false;
+            //     }
+            // }
             self.sdi12_board.delay_us(TIMING_TOLERANCE);
             return true;
         }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -251,14 +251,15 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                 Some(byte) => {
                     // store the byte in the response buffer
                     buffer[bytes_read] = byte;
-                    // defmt::println!("buffer[{}] = {}", bytes_read, byte);
                     bytes_read += 1;
                     if byte == '!' {
+                        defmt::println!("buffer[{}] = {}", bytes_read, byte);
                         break;
                     }
                 },
                 None => {
                     defmt::println!("Timeout error");
+                    defmt::println!("buffer[{}] = {}", bytes_read, buffer);
                     break; // SDI12_timeout or error
                 }
             }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -62,19 +62,21 @@ impl<B> SDI12<B> where B: BoardForSDI12,
 
     pub fn set_state(&mut self, state: SDIPinState) {
         // set the digital pin to the specified value
-        self.state = state;
-        match self.state {
-            SDIPinState::Sdi12Transmitting => {
-                // set pin mode to OUTPUT
-                self.sdi12_board.pin_mode(gpio::GpioMode::PushPullOutput);
-            },
-            SDIPinState::Sdi12Listening => {
-                // set pin mode to INPUT
-                self.sdi12_board.pin_mode(gpio::GpioMode::FloatingInput);
-            }
-            _ => {
-                // For SDI12_HOLDING, SDI12_DISABLED and SDI12_ENABLED, set pin mode to INPUT
-                self.sdi12_board.pin_mode(gpio::GpioMode::FloatingInput);
+        if self.state != state {
+            self.state = state;
+            match self.state {
+                SDIPinState::Sdi12Transmitting => {
+                    // set pin mode to OUTPUT
+                    self.sdi12_board.pin_mode(gpio::GpioMode::PushPullOutput);
+                },
+                SDIPinState::Sdi12Listening => {
+                    // set pin mode to INPUT
+                    self.sdi12_board.pin_mode(gpio::GpioMode::PullDownInput);
+                }
+                _ => {
+                    // For SDI12_HOLDING, SDI12_DISABLED and SDI12_ENABLED, set pin mode to INPUT
+                    self.sdi12_board.pin_mode(gpio::GpioMode::PullDownInput);
+                }
             }
         }
     }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -190,7 +190,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             iter_count += 1;
             self.sdi12_board.delay_us(1000);
         }
-        defmt::println!("detected a start bit");
+        // defmt::println!("detected a start bit");
         self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT / 2);
 
         if self.sdi12_board.read() == false {
@@ -251,7 +251,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                 Some(byte) => {
                     // store the byte in the response buffer
                     buffer[bytes_read] = byte;
-                    defmt::println!("buffer[{}] = {}", bytes_read, byte);
+                    // defmt::println!("buffer[{}] = {}", bytes_read, byte);
                     bytes_read += 1;
                     if byte == '!' {
                         break;
@@ -292,7 +292,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                     // store the byte in the response buffer
                     buffer[bytes_read] = byte;
                     bytes_read += 1;
-                    defmt::println!("buffer[{}] = {}", bytes_read, byte);
+                    // defmt::println!("buffer[{}] = {}", bytes_read, byte);
                     if byte == '\n' {
                         break;
                     }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -303,88 +303,16 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                 }
             }
         }
+        self.sdi12_board.delay_us(SDI12_GAP);
         buffer
     }
 
-    pub fn send_m_command(&mut self, address: char, id: char) -> SDI12_MResponse {
-        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
-        command[0] = address;
-        command[1] = 'M';
-        if id == '\0' {
-            command[2] = '!';
-        }
-        else {
-            command[2] = id;
-            command[3] = '!';
-        }
-        self.send_break();
-        self.sdi12_board.delay_us(SDI12_GAP);
-        self.send_command(command);
-        defmt::println!("Sent 0M0!");
-        let response = self.read_response();
-        // parse the response
-        // format: <address>tttn<CR><LF>
-        let address_r = response[0];
-        if address_r != address {
-            // invalid response
-            return SDI12_MResponse {
-                address: '\0',
-                ttt: 0,
-                n: 0
-            };
-        }
-
-        let ttt = &response[1..4];
-        // convert ttt from ASCII to integer
-        let mut result: u32 = 0; // Or u32, usize, etc.
-
-        for &c in ttt {
-            // to_digit(10) converts the char to a number from 0-9
-            let digit = c.to_digit(10);
-            if let Some(d) = digit {
-                result = (result * 10) + d as u32;
-            }
-        }
-
-        let n : u8 = response[4].to_digit(10).unwrap_or(0) as u8; // convert ASCII to integer
-
-        self.sdi12_board.delay_us(SDI12_GAP);
-        
-        SDI12_MResponse {
-            address: address_r,
-            ttt: result,
-            n: n
-        }
-    }
-
-    pub fn send_d0_command(&mut self, address: char, num_data: u8) -> SDI12_Dresponse {
-        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
-        command[0] = address;
-        command[1] = 'D';
-        command[2] = '0';
-        command[3] = '!';
-        let mut resp : SDI12_Dresponse = SDI12_Dresponse {
-            address: '\0',
-            data: [0.0; 9],
-            count: 0,
-            terminate: false,
-            last_d_ind: 0
-        };
-        self.send_command(command);
-        defmt::println!("Sent 0D0!");
-        let response = self.read_response();
-        // parse the response
-        // format: <address><data><CR><LF>
-        let address_r = response[0];
-        if address_r != address {
-            // invalid response
-            return resp;
-        }
-        resp.address = address_r;
-        let response = &response[1..SDI12_BUFFER_SIZE];
+    pub fn parse_data(&mut self, response: &[char]) -> ([f32; 9], u8) {
         let mut count = 0;
         let mut temp_buf = [0u8; 16]; 
         let mut temp_len = 0;
+
+        let mut data: [f32; 9] = [0_f32; 9];
 
         for &c in response {
             if c == '+' || c == '-' || c == '\r' || c == '\n' {
@@ -393,7 +321,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                     if let Ok(s) = core::str::from_utf8(&temp_buf[..temp_len]) {
                         // Parse the float
                         if let Ok(val) = s.parse::<f32>() {
-                            resp.data[count] = val;
+                            data[count] = val;
                             count += 1;
                         }
                     }
@@ -414,16 +342,8 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                 temp_len += 1;
             }
         }
-        
-        if count == num_data as usize {
-            resp.terminate = true;
-        }
 
-        resp.count = count as u8;
-        
-        self.sdi12_board.delay_us(SDI12_GAP);
-
-        resp
+        (data, count as u8)
     }
 
 }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -87,24 +87,24 @@ impl<B> SDI12<B> where B: BoardForSDI12,
         self.set_state(SDIPinState::Sdi12Transmitting);
         
         // Hold it HIGH for 12 ms
-        self.sdi12_board.write(true);
+        self.sdi12_board.write(false);
         self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US);
         
         // Marking by holding it LOW for 8.33 ms
-        self.sdi12_board.write(false);
+        self.sdi12_board.write(true);
         self.sdi12_board.delay_us(SDI12_MARK_DURATION_US);
     }
 
     pub fn receive_break(&mut self) -> bool {   
         self.set_state(SDIPinState::Sdi12Listening);
-        if self.sdi12_board.read() == true {
+        if self.sdi12_board.read() == false {
             // defmt::println!("Start for 12ms");
             self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US - SDI12_TIMING_TOLERANCE);
             let mut iter_count = 0;
-            while self.sdi12_board.read() {
+            while self.sdi12_board.read() == false {
                 // defmt::println!("iter_count: {}", iter_count);
                 if iter_count > 10 {
-                    defmt::println!("Timeout! line is not falling low");
+                    defmt::println!("Timeout! line is not pulling up");
                     return false;
                 }
                 iter_count += 1;
@@ -131,7 +131,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             //     iter_count += 1;
             // }
             self.sdi12_board.delay_us(SDI12_MARK_DURATION_US - 2 * SDI12_TIMING_TOLERANCE);
-            if self.sdi12_board.read() {
+            if self.sdi12_board.read() == false {
                 defmt::println!("Invalid marking");
                 return false;
             }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -229,14 +229,13 @@ impl<B> SDI12<B> where B: BoardForSDI12,
 
     pub fn send_command(&mut self, command: [char; SDI12_COMMAND_SIZE]) {
         // sdi-12 implementation
-        self.send_break();
-        self.sdi12_board.delay_us(10000);
+        self.set_state(SDIPinState::Sdi12Transmitting);
         for c in command.iter() {
             self.write_char(*c);
             if *c == '!' {
                 break; // stop at termination character
             }
-            self.sdi12_board.delay_us(10000);
+            self.sdi12_board.delay_us(SDI12_GAP);
         }
         self.set_state(SDIPinState::Sdi12Listening);
     }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -260,6 +260,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             command[3] = '!';
         }
         self.send_command(command);
+        defmt::println!("Sent 0M0!");
         let response = self.read_response();
         // parse the response
         // format: <address>tttn<CR><LF>

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -2,14 +2,15 @@
 
 use rriv_board::gpio;
 
-const TIMING_TOLERANCE: u16 = 1000;
-const SDI12_BREAK_DURATION_US: u16 = 12000 + TIMING_TOLERANCE;
+const TIMING_TOLERANCE: u16 = 400;
+const SDI12_BREAK_DURATION_US: u16 = 12000;
 const SDI12_MARK_DURATION_US: u16 = 8333;
 const SDI12_TICKS_PER_BIT: u16 = 8333; // 1 bit duration at 1200 baud
-const SDI12_TIMEOUT : u32 = 1000; // timeout for reading response in milliseconds
+// const SDI12_TIMEOUT : u32 = 100; // timeout for reading response in milliseconds
 pub const SDI12_BUFFER_SIZE: usize = 100; // size of the buffer for reading responses
 pub const SDI12_COMMAND_SIZE: usize = 10;
 
+#[derive(PartialEq, Debug)]
 pub enum SDIPinState {
     Sdi12Disabled,         // SDI-12 is disabled, pin mode INPUT, interrupts disabled for the pin
     Sdi12Enabled,          // SDI-12 is enabled, pin mode INPUT, interrupts disabled for the pin 
@@ -84,32 +85,48 @@ impl<B> SDI12<B> where B: BoardForSDI12,
         
         // Hold it HIGH for 12 ms
         self.sdi12_board.write(true);
-        self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US);
+        self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US + TIMING_TOLERANCE);
         
         // Marking by holding it LOW for 8.33 ms
         self.sdi12_board.write(false);
         self.sdi12_board.delay_us(SDI12_MARK_DURATION_US);
     }
 
-    pub fn receive_break(&mut self) -> bool {
+    pub fn receive_break(&mut self) -> bool {   
         self.set_state(SDIPinState::Sdi12Listening);
-        let mut is_valid_break = true;
         if self.sdi12_board.read() == true {
+            defmt::println!("Start for 12ms");
             // check after every 1ms for 12 times to see if it is a valid break
             for _ in 0..12 {
                 self.sdi12_board.delay_us(1000); // Wait 1ms
                 
                 if self.sdi12_board.read() == false {
-                    is_valid_break = false;
-                    break;
+                    defmt::println!("Line dropped low before 12ms");
+                    return false;
                 }
             }
-            if is_valid_break {
-                // wait for the line to drop LOW
-                while self.sdi12_board.read() == true {}
+            defmt::println!("Valid break, waiting...");
+            // wait for the line to drop LOW
+            let mut iter_count = 0;
+            while self.sdi12_board.read() == true {
+                if iter_count > 1 {
+                    defmt::println!("Timeout! line is not falling low");
+                    return false;
+                }
+                self.sdi12_board.delay_us(TIMING_TOLERANCE);
+                iter_count += 1;
             }
+            for _ in 0..8 {
+                self.sdi12_board.delay_us(1000);
+                if self.sdi12_board.read() {
+                    defmt::println!("line went high too early, invalid marking");
+                    return false;
+                }
+            }
+            self.sdi12_board.delay_us(TIMING_TOLERANCE);
+            return true;
         }
-        is_valid_break
+        return false;
     }
 
     pub fn write_char(&mut self, c: char) {
@@ -180,11 +197,13 @@ impl<B> SDI12<B> where B: BoardForSDI12,
     pub fn send_command(&mut self, command: [char; SDI12_COMMAND_SIZE]) {
         // sdi-12 implementation
         self.send_break();
+        self.sdi12_board.delay_us(10000);
         for c in command.iter() {
             self.write_char(*c);
             if *c == '!' {
                 break; // stop at termination character
             }
+            self.sdi12_board.delay_us(10000);
         }
         self.set_state(SDIPinState::Sdi12Listening);
     }
@@ -223,6 +242,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             if *c == '\n' {
                 break; // stop at termination character
             }
+            self.sdi12_board.delay_us(10000);
         }
         self.set_state(SDIPinState::Sdi12Listening);
     }
@@ -293,6 +313,8 @@ impl<B> SDI12<B> where B: BoardForSDI12,
         }
 
         let n : u8 = response[4].to_digit(10).unwrap_or(0) as u8; // convert ASCII to integer
+
+        self.sdi12_board.delay_us(10000);
         
         SDI12_MResponse {
             address: address_r,
@@ -364,6 +386,8 @@ impl<B> SDI12<B> where B: BoardForSDI12,
         }
 
         resp.count = count as u8;
+        
+        self.sdi12_board.delay_us(10000);
 
         resp
     }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -200,12 +200,14 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                 Some(byte) => {
                     // store the byte in the response buffer
                     buffer[bytes_read] = byte;
+                    defmt::println!("buffer[{}] = {}", bytes_read, byte);
                     bytes_read += 1;
                     if byte == '!' {
                         break;
                     }
                 },
                 None => {
+                    defmt::println!("Timeout error");
                     break; // SDI12_timeout or error
                 }
             }
@@ -228,6 +230,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
     pub fn read_response(&mut self) -> [char; SDI12_BUFFER_SIZE] {
         // sdi-12 implementation
         self.set_state(SDIPinState::Sdi12Listening);
+        defmt::println!("Reading response...");
         let mut buffer: [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
         let mut bytes_read = 0;
         while bytes_read < SDI12_BUFFER_SIZE {
@@ -237,11 +240,13 @@ impl<B> SDI12<B> where B: BoardForSDI12,
                     // store the byte in the response buffer
                     buffer[bytes_read] = byte;
                     bytes_read += 1;
+                    defmt::println!("buffer[{}] = {}", bytes_read, byte);
                     if byte == '\n' {
                         break;
                     }
                 },
                 None => {
+                    defmt::println!("Timeout SDI12");
                     break; // SDI12_timeout or error
                 }
             }
@@ -310,6 +315,7 @@ impl<B> SDI12<B> where B: BoardForSDI12,
             last_d_ind: 0
         };
         self.send_command(command);
+        defmt::println!("Sent 0D0!");
         let response = self.read_response();
         // parse the response
         // format: <address><data><CR><LF>


### PR DESCRIPTION
- **first mhz9041a driver**
- **updating mhz9041a driver registry**
- **adding mhz9041a debug logging**
- **two defaul addresses**
- **revising mhz9041 driver**
- **first mhz9041a driver**
- **updating mhz9041a driver registry**
- **adding mhz9041a debug logging**
- **two defaul addresses**
- **revising mhz9041 driver**
- **fix 6 ring addresses**
- **fix: changing six ring sensor addresses**
- **chore(release): 1.12.6 [skip ci]**
- **wip: sdi12 skeleton**
- **fix: cargo setup for sdi12**
- **feat: added delay_us fn in rriv board**
- **feat: created driver for sdi12**
- **feat: created sdi12 library**
- **feat: created sdi12 service**
- **feat: added sdi12 enable and datalogger mode**
- **fix: rebase merge error fixed**
- **fix: registry merge conflicts**
- **fix: sensor name len exceeded**
- **fix: precise delay cast error**
- **feat: added debug statements**
- **fix: millis overlapping fixed**
- **fix: setting up SDI12 datalogger mode**
- **feat: commented out uart message**
- **feat: added debug statements**
- **fix: mack fn ascii conversion fixed**
- **feat: timing tolerance added**
- **fix: set state only if not equal**
- **fix: timeout millis not working**
- **feat: added timing gaps bewteen every event**
- **fix: receive break with relaxed constraints**
- **fix: no sending of break before every command**
- **feat: commented out defmt statements**
- **feat: updated driver to use sdi12_service**
- **feat: code organisation changes**
- **feat: tightened timing constraints**
- **fix: add some defaults for settings bools struct**
- **fix: move defmt out of loop**
- **wip: start handling data response from configured sensors**
- **wip: fixes and features to SDI-12**
