### PR TITLE
low power modes 2

### DIFF
--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -73,6 +73,8 @@ pub trait RRIVBoard: Send {
     fn get_battery_level(&mut self) -> f32;
 
     fn sleep(&mut self, milliseconds: u64);
+    fn standby(&mut self, minutes: u32);
+
 
     // low level board functionality
     // for debugging and basic operation

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -72,7 +72,7 @@ pub trait RRIVBoard: Send {
 
     fn get_battery_level(&mut self) -> f32;
 
-    fn sleep(&mut self);
+    fn sleep(&mut self, milliseconds: u64);
 
     // low level board functionality
     // for debugging and basic operation
@@ -116,6 +116,8 @@ pub trait RRIVBoard: Send {
 
     fn get_errors(&self) -> [HardwareError; 5]; // return up to 5 hardware errors currently raised
     fn error_alarm(&mut self); // activate a generic error alarm, normally an LED
+
+
     
 }
 

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -70,7 +70,7 @@ pub trait RRIVBoard: Send {
     fn millis(&mut self) -> u32;
 
 
-    fn get_battery_level(&mut self) -> i16;
+    fn get_battery_level(&mut self) -> f32;
 
     fn sleep(&mut self);
 

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -73,7 +73,7 @@ pub trait RRIVBoard: Send {
     fn get_battery_level(&mut self) -> f32;
 
     fn sleep(&mut self, milliseconds: u64);
-    fn standby(&mut self, minutes: u32);
+    fn standby(&mut self, interval: u32);
 
 
     // low level board functionality

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -66,7 +66,7 @@ pub trait RRIVBoard: Send {
     fn rs485_send(&mut self, message : &[u8]);
     fn serial_debug(&mut self, args: fmt::Arguments);
     fn delay_ms(&mut self, ms: u16);
-    fn timestamp(&mut self) -> i64;
+    fn seconds(&mut self) -> u32;
     fn millis(&mut self) -> u32;
 
 

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -73,7 +73,7 @@ pub trait RRIVBoard: Send {
     fn get_battery_level(&mut self) -> f32;
 
     fn sleep(&mut self, milliseconds: u64);
-    fn standby(&mut self, interval: u32);
+    fn standby(&mut self, interval: u16);
 
 
     // low level board functionality

--- a/board/rriv_board_0_4_2/src/components/battery_level.rs
+++ b/board/rriv_board_0_4_2/src/components/battery_level.rs
@@ -13,13 +13,23 @@ impl BatteryLevel {
     }
   }
 
-  pub fn measure_battery_level(&mut self, adc: &mut InternalAdc, delay: &mut impl DelayMs<u16>) -> Result<u16, AdcError> {
+  pub fn measure_battery_level(&mut self, adc: &mut InternalAdc, delay: &mut impl DelayMs<u16>) -> Result<f32, AdcError> {
 
     self.pins.enable_vin_measure.set_low();
     delay.delay_ms(1000_u16);
-    let value = adc.read_battery_level();
+    let oversample_count = 10;
+    let mut oversample_value: u32 = 0;
+    for i in 0..oversample_count {
+      match adc.read_battery_level(){
+        Ok(value) => oversample_value = oversample_value + value as u32,
+        Err(err) => return Err(err),
+      }
+    }
     self.pins.enable_vin_measure.set_high();
-    value
+    let value = oversample_value / oversample_count;
+    // convert to voltage
+    let voltage = 3.3_f32 * value as f32 / 4096_f32;
+    Ok( voltage )
 
   }
 }

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -205,20 +205,24 @@ impl Board {
             let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
             let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
             let sclk_led_enable = gpiob.pb13.into_push_pull_output_with_state(&mut gpiob.crh, gpio::PinState::Low);
+            let mut sclk_led_enable: Pin<'B', 13, Output> = sclk_led_enable.into_floating_input(&mut gpiob.crh).into_push_pull_output(&mut gpiob.crh);
+            sclk_led_enable.set_high();
             (cs, sclk_led_enable, pwm_pin)
         };
+
+    
         cs.set_high();
-        cortex_m::asm::delay(5000);
+        cortex_m::asm::delay(555000);
         cs.set_low();
-        cortex_m::asm::delay(5000);
+        cortex_m::asm::delay(555000);
         cs.set_high();
-        cortex_m::asm::delay(5000);
+        cortex_m::asm::delay(555000);
         cs.set_low();
-        cortex_m::asm::delay(5000);
+        cortex_m::asm::delay(555000);
         cs.set_high();
-        cortex_m::asm::delay(5000);
+        cortex_m::asm::delay(555000);
         cs.set_low();
-        cortex_m::asm::delay(5000);
+        cortex_m::asm::delay(555000);
 
         defmt::println!("try stdby"); defmt::flush();
 
@@ -251,7 +255,7 @@ impl Board {
 
         let alarm_time = start_sleep + seconds; // test with 2 sec
         rtc.set_alarm(alarm_time); 
-       
+
         // Go into standby
         defmt::println!("go into stdby");
 
@@ -1187,7 +1191,7 @@ fn usb_interrupt(cs: &CriticalSection) {
 }
 
 pub fn build() -> Board {
-    Board::check_entry_standby();
+    // Board::check_entry_standby();
     let mut board_builder = BoardBuilder::new();
     board_builder.setup();
     let board = board_builder.build();
@@ -1493,10 +1497,8 @@ impl BoardBuilder {
     fn setup(&mut self) {
         defmt::println!("board builder setup");
 
-        let mut core_peripherals: pac::CorePeripherals = cortex_m::Peripherals::take().unwrap();
-        let device_peripherals: pac::Peripherals = pac::Peripherals::take().unwrap();
-
-     
+        let mut core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
+        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
 
         // mcu device registers
         let rcc = device_peripherals.RCC.constrain();

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1322,6 +1322,14 @@ impl BoardBuilder {
             usb_pins,
         ) = pin_groups::build(pins, &mut gpio_cr);
 
+        power_pins.enable_3v.set_high();
+        // delay.delay_ms(500_u32);
+        // power_pins.enable_3v.set_low();
+        // delay.delay_ms(500_u32);
+        // power_pins.enable_3v.set_high();
+        // delay.delay_ms(1000_u32);
+
+
         let clocks =
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
 
@@ -1373,13 +1381,6 @@ impl BoardBuilder {
 
         self.external_adc = Some(ExternalAdc::new(external_adc_pins));
         self.external_adc.as_mut().unwrap().disable(&mut delay);
-
-        power_pins.enable_3v.set_high();
-        delay.delay_ms(500_u32);
-        power_pins.enable_3v.set_low();
-        delay.delay_ms(500_u32);
-        power_pins.enable_3v.set_high();
-        delay.delay_ms(500_u32);
 
         // external adc and i2c stability require these steps
         power_pins.enable_5v.set_high();

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -177,6 +177,16 @@ impl Board {
             // it will need to be standby seconds, to account for seconds we are off
             // calculated before going into standby using the exRTC
             // clear enter_standby, so that the measurement loop will run on restart
+
+            let mut flash = device_peripherals.FLASH.constrain();
+
+            let clocks = rcc.cfgr
+            .sysclk(SYSCLK_MHZ.MHz())
+            .pclk1(PCLK_MHZ.MHz())
+            // .adcclk(14.MHz())
+            .freeze(&mut flash.acr);
+
+
             let rtc = Rtc::new(device_peripherals.RTC, &mut backup_domain); // TODO: make sure LSE on and running?
             Board::standby(10, rtc, core_peripherals);
         } 
@@ -186,6 +196,29 @@ impl Board {
 
      fn standby(seconds: u32, mut rtc: Rtc, mut core_peripherals: pac::CorePeripherals){
          // Try Standby
+
+          let (mut cs, mut sclk_led_enable, pwm_pin) = unsafe {
+            let device_peripherals_steal: pac::Peripherals = pac::Peripherals::steal();
+            let mut gpioc = device_peripherals_steal.GPIOC.split();
+            let cs = gpioc.pc8;
+            let cs = cs.into_push_pull_output(&mut gpioc.crh);
+            let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+            let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
+            let sclk_led_enable = gpiob.pb13.into_push_pull_output_with_state(&mut gpiob.crh, gpio::PinState::Low);
+            (cs, sclk_led_enable, pwm_pin)
+        };
+        cs.set_high();
+        cortex_m::asm::delay(5000);
+        cs.set_low();
+        cortex_m::asm::delay(5000);
+        cs.set_high();
+        cortex_m::asm::delay(5000);
+        cs.set_low();
+        cortex_m::asm::delay(5000);
+        cs.set_high();
+        cortex_m::asm::delay(5000);
+        cs.set_low();
+        cortex_m::asm::delay(5000);
 
         defmt::println!("try stdby"); defmt::flush();
 
@@ -236,31 +269,6 @@ impl Board {
         defmt::println!("should not reach here");
     }
    
-    pub fn enter_stop_mode(&mut self) {
-        //           debug("setting up EXTI");
-        //   *bb_perip(&EXTI_BASE->IMR, EXTI_RTC_ALARM_BIT) = 1;
-        // 	*bb_perip(&EXTI_BASE->RTSR, EXTI_RTC_ALARM_BIT) = 1;
-
-        // in addition to the RTCALARM interrupt, the rtc must route through EXTI to wake the MCU up from stop mode.
-        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
-        device_peripherals.EXTI.imr.write(
-            |w| w.mr17().set_bit(), // interrupt mask bit 17 enables RTC EXTI
-        );
-        device_peripherals.EXTI.rtsr.write(
-            |w| w.tr17().set_bit(), // rising trigger bit 17 enables RTC EXTI
-        );
-
-        // clocks
-        // steal and use raw the same function sin cfgr to switch to hsi and wait for stabilization
-        // and the same thing to switch back.
-        // let clocks = cfgr
-        //     .use_hse(8.MHz())
-        //     .sysclk(48.MHz())
-        //     .pclk1(24.MHz())
-        //     .adcclk(14.MHz())
-        //     .freeze(flash_acr);
-    }
-
     fn disable_interrupts(&self) {
         // disable interrupts
         cortex_m::interrupt::disable();

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -429,13 +429,13 @@ impl RRIVBoard for Board {
         return self.get_millis();
     }
 
-    fn get_battery_level(&mut self) -> i16 {
+    fn get_battery_level(&mut self) -> f32 {
         match self
             .battery_level
             .measure_battery_level(&mut self.internal_adc, &mut self.delay)
         {
-            Ok(value) => return value as i16,
-            Err(_err) => return -1,
+            Ok(value) => return value as f32,
+            Err(_err) => return -1.0,
         }
     }
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -326,12 +326,12 @@ impl Board {
     // let _pb3 = gpiob.pb3.into_analog(&mut gpiob.crl);
     // let _pb4 = gpiob.pb4.into_analog(&mut gpiob.crl);
     let _pb5 = gpiob.pb5.into_push_pull_output(&mut gpiob.crl).set_low(); // gpio2
-    let _pb6 = gpiob.pb6.into_pull_down_input(&mut gpiob.crl); // i2c1_scl
-    let _pb7 = gpiob.pb7.into_pull_down_input(&mut gpiob.crl); // i2c1_sda
+    let _pb6 = gpiob.pb6.into_pull_up_input(&mut gpiob.crl); // i2c1_scl
+    let _pb7 = gpiob.pb7.into_pull_up_input(&mut gpiob.crl); // i2c1_sda
     let _pb8 = gpiob.pb8.into_push_pull_output(&mut gpiob.crh).set_low(); // gpio1
     let _pb9 = gpiob.pb9.into_analog(&mut gpiob.crh); // unused
-    let _pb10 = gpiob.pb10.into_pull_down_input(&mut gpiob.crh); // i2c2_scl
-    let _pb11 = gpiob.pb11.into_pull_down_input(&mut gpiob.crh); // i2c2_sda
+    let _pb10 = gpiob.pb10.into_pull_up_input(&mut gpiob.crh); // i2c2_scl
+    let _pb11 = gpiob.pb11.into_pull_up_input(&mut gpiob.crh); // i2c2_sda
     let _pb12 = gpiob.pb12.into_push_pull_output(&mut gpiob.crh).set_low(); // enable_5v
     let _pb13 = gpiob.pb13.into_push_pull_output(&mut gpiob.crh).set_low(); // spi2_sck
     let _pb14 = gpiob.pb14.into_push_pull_output(&mut gpiob.crh).set_low(); // spi2_miso
@@ -369,6 +369,10 @@ impl Board {
     let _pd0 = gpiod.pd0.into_push_pull_output(&mut gpiod.crl).set_low(); // Skip if using LSE
     let _pd1 = gpiod.pd1.into_push_pull_output(&mut gpiod.crl).set_low(); // Skip if using LSE
     let _pd2 = gpiod.pd2.into_push_pull_output(&mut gpiod.crl).set_low(); 
+
+
+    // Disable both JTAG and SWD debug interface before Standby
+    afio.mapr.modify_mapr(|_, w| unsafe { w.swj_cfg().bits(0b010) }); // 0b010 = full disable
 
         // Go into standby
         defmt::println!("go into stdby");

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -279,8 +279,26 @@ impl Board {
     // enable_3v: Pin<'C', 5>,
     //   enable_5v: Pin<'B', 12>,
 
+    // these didn't make a different
     device_peripherals_steal.ADC1.cr2.modify(|_, w| w.adon().clear_bit());
     device_peripherals_steal.RCC.apb2enr.modify(|_, w| w.adc1en().clear_bit());
+
+    // Enable backup domain write access (clears DBP bit in PWR_CR)
+    // rcc_cfgr.bkp.enable(&mut rcc.apb1, &mut bkp);
+
+    // Now we can modify the backup domain registers
+    // Use the RTC's handle to get to the BDCR register
+    // let mut rtc_handle = rtc.constrain(&mut rcc_cfgr.bkp, &mut pwr);
+    // rtc_handle.free(); // Release the handle to access BDCR directly
+
+    // Clear LSEON bit
+    device_peripherals_steal.RCC.bdcr.modify(|_, w| w.lseon().clear_bit());
+
+    // Wait for LSE to fully shut down (LSERDY will clear after ~6 LSE cycles)
+    while device_peripherals_steal.RCC.bdcr.read().lserdy().bit_is_set() {}
+
+    // Optionally disable backup domain write access to save additional power
+    // rcc_cfgr.bkp.disable(&mut rcc.apb1);
 
 
     // GPIOA (Pins 0-15)
@@ -299,7 +317,7 @@ impl Board {
     let _pa12 = gpioa.pa12.into_push_pull_output(&mut gpioa.crh).set_low(); // usb_p
     // let _pa13 = gpioa.pa13.into_analog(&mut gpioa.crh);  // SWDIO
     // let _pa14 = gpioa.pa14.into_analog(&mut gpioa.crh);  // SWCLK
-    // let _pa15 = gpioa.pa15.into_analog(&mut gpioa.crh);
+    // let _pa15 = gpioa.pa15.into_analog(&mut gpioa.crh); // JTDI, handled below
     
     // GPIOB (Pins 0-15)
     let _pb0 = gpiob.pb0.into_analog(&mut gpiob.crl); // vin_measure
@@ -326,7 +344,7 @@ impl Board {
     let _pc3 = gpioc.pc3.into_analog(&mut gpioc.crl); // internal_adc2
     let _pc4 = gpioc.pc4.into_analog(&mut gpioc.crl); // unused
     let _pc5 = gpioc.pc5.into_push_pull_output(&mut gpioc.crl).set_low(); // enable_3v
-    let _pc6 = gpioc.pc6.into_push_pull_output(&mut gpioc.crl).set_high(); // exADC mosfet
+    let _pc6 = gpioc.pc6.into_push_pull_output(&mut gpioc.crl).set_high(); // exADC enable mosfet, high is off
     let _pc7 = gpioc.pc7.into_push_pull_output(&mut gpioc.crl).set_low(); // duplicated? // unused
     let _pc8 = gpioc.pc8.into_push_pull_output(&mut gpioc.crh).set_low(); // SD Card CS
     let _pc9 = gpioc.pc9.into_analog(&mut gpioc.crh); // unused
@@ -335,7 +353,7 @@ impl Board {
     let _pc12 = gpioc.pc12.into_push_pull_output(&mut gpioc.crh).set_low(); // gpio6
     // PC13, PC14, PC15 are special pins - usually reserved for LSE/RTC
     // If you need to configure them as analog, do so carefully
-    let _pc13 = gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_low(); //enable HSE
+    let _pc13 = gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_low(); //enable HSE set low to disabl
     // For PC14 and PC15 (LSE pins), DO NOT configure as analog if using LSE
     let _pc14 = gpioc.pc14.into_push_pull_output(&mut gpioc.crh).set_low(); // Skip if using LSE
     let _pc15 = gpioc.pc15.into_push_pull_output(&mut gpioc.crh).set_low();  // Skip if using LSE
@@ -1047,7 +1065,7 @@ impl RRIVBoard for Board {
         // minutes doesn't mean anything here yet.
         // this is really about 'interval' and calculating the seconds until the next wake
         // and then put them into the backup register and reset
-        let seconds = 20;
+        let seconds = 500;
         self.backup_domain.write_data_register_high(2, seconds);
         self.backup_domain.write_data_register_low(2, 0b1);
         SCB::sys_reset(); // reset so we can standby without the watchdog enabled.

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
+use cortex_m::peripheral::syst;
 use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
 use rriv_board::hardware_error::{HardwareError};
@@ -150,40 +151,7 @@ impl Board {
 
     }
 
-    pub fn sleep_mcu(&mut self) {
-        // TODO: sleep mode won't work with independent watch dog, unless we can stop it.
-        // EDIT: there is not alternative source for indep watchdog, it's always HSI
-        // EDIT: therefore field mode must restart with indep watchdog disabled
-
-        self.internal_rtc.set_alarm(5000); // 5 seconds?
-        self.internal_rtc.listen_alarm();
-        defmt::println!("will sleep");
-
-        // disable interrupts
-        NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);
-        NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0);
-        NVIC::mask(pac::Interrupt::USART2);
-
-        unsafe { NVIC::unmask(pac::Interrupt::RTCALARM) };
-        cortex_m::asm::dsb();
-
-        let mut core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
-        core_peripherals.SYST.disable_interrupt();
-
-        cortex_m::asm::wfi();
-
-        core_peripherals.SYST.enable_interrupt();
-
-        cortex_m::asm::isb();
-
-        // re-enable interrupts
-        unsafe { NVIC::unmask(pac::Interrupt::USB_HP_CAN_TX) };
-        unsafe { NVIC::unmask(pac::Interrupt::USB_LP_CAN_RX0) };
-        unsafe { NVIC::unmask(pac::Interrupt::USART2) };
-
-        defmt::println!("woke from sleep");
-    }
-
+   
     pub fn enter_stop_mode(&mut self) {
         //           debug("setting up EXTI");
         //   *bb_perip(&EXTI_BASE->IMR, EXTI_RTC_ALARM_BIT) = 1;
@@ -422,7 +390,7 @@ impl RRIVBoard for Board {
 
     fn get_millis(&mut self) -> u32 {
         let millis = self.counter.now();
-        let millis = millis.ticks();
+        let millis = millis.ticks();  
         millis
     }
 
@@ -438,12 +406,6 @@ impl RRIVBoard for Board {
             Ok(value) => return value as f32,
             Err(_err) => return -1.0,
         }
-    }
-
-    fn sleep(&mut self) {
-        // need to extend IndependentWatchdog to sleep the watch dog
-        // self.watchdog.acc
-        self.watchdog.feed();
     }
 
     fn set_debug(&mut self, debug: bool) {
@@ -890,8 +852,97 @@ impl RRIVBoard for Board {
         }
     }
 
+    fn sleep(&mut self, milliseconds: u64) {
+        // TODO: sleep mode won't work with independent watch dog, unless we can stop it.
+        // EDIT: there is not alternative source for indep watchdog, it's always HSI
+        // EDIT: therefore field mode must restart with indep watchdog disabled
+        // sleeping just needs to happen in units less that indep watchdog, but stop mode need restart and disable
+        // if we wake from sleep should we go ahead and reset again to enable the watchdog during processing?
+
+        // This connects the RTC alarm event to the NVIC for wake-up
+        let exti = unsafe { &(*pac::EXTI::ptr()) };
+        // exti.pr.modify(|_, w| w.pr17().set_bit());
+        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
+
+        // Enable interrupt on EXTI line 17
+        exti.imr.modify(|_, w| w.mr17().set_bit());     // Unmask interrupt
+        exti.emr.modify(|_, w| w.mr17().set_bit());     // Enable event (for wake from sleep)
+        exti.rtsr.modify(|_, w| w.tr17().set_bit());     // Rising edge trigger
+
+        // NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  // it's OK to wake up and do work
+        // NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); // to keep interacting with the user
+        NVIC::mask(pac::Interrupt::USART2);
+        unsafe {
+            NVIC::unmask(pac::Interrupt::RTCALARM);
+        }
+
+        // To detect if a debugger is attached to an STM32F103RB, you can check the DBGMCU_CR control register within the microcontroller.  Specifically, reading the bottom 3 bits of this register will indicate an active debug session, as these bits are set to 1 when a debugger attaches and default to 0 after a power-on reset.
+
+        // if we are debugging, we need this.  but this interferes with actual low power modes
+        // #[cfg(debug_assertions)]
+        // {
+            let dbgmcu = unsafe { &(*pac::DBGMCU::ptr()) };
+            dbgmcu.cr.modify(|_, w| w.dbg_sleep().set_bit());  // Enable debug in sleep
+        // }
+
+        let mut remainder: u32 = milliseconds;
+        
+        defmt::println!("try sleep {}", milliseconds);
+
+        let macrosleep_interval_s = WATCHDOG_TIMEOUT - 2;
+        while remainder > macrosleep_interval_s * 1000 {
+            self.watchdog.feed(); 
+            
+            // self.internal_rtc.set_time(0);
+            // cortex_m::asm::delay(100);  // RTC sync
+            pac::NVIC::unpend(pac::Interrupt::RTCALARM);
+            exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
+            self.internal_rtc.set_alarm(self.internal_rtc.current_time() + macrosleep_interval_s); // sleep in units of WATCHDOG_TIMEOUT - 2, triggers on the actual time
+            defmt::println!("will sleep {}", self.internal_rtc.current_time() );  
+
+            cortex_m::asm::dsb();
+
+            let mut core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
+            core_peripherals.SYST.disable_interrupt();
+
+            cortex_m::asm::wfi();
+
+            core_peripherals.SYST.enable_interrupt();
+
+            // self.internal_rtc.clear_alarm_flag();
+            defmt::println!("did sleep {}", self.internal_rtc.current_time() );  defmt::flush();
+            usb_serial_send("sleeping", &mut self.delay);
+            remainder = remainder - macrosleep_interval_s * 1000;
+
+        }
+        self.watchdog.feed(); 
+        defmt::println!("woke from sleep");
+        // handle the rest of the sleep, the remaining milliseconds
+        unsafe {
+            NVIC::unmask(pac::Interrupt::USART2);
+        }
+        NVIC::mask(pac::Interrupt::RTCALARM);
+        
+    }
+
 }
 
+
+#[interrupt]
+unsafe fn RTCALARM() {
+    defmt::println!("got RTCALARM interrupt"); defmt::flush();
+    // The `rtc.listen_alarm()` call has already configured the EXTI line.
+    // This function will be called when the alarm triggers.
+    // Usually, we just clear the pending flag here. The main loop will handle the event.
+    // NOTE: Be careful with shared state if you do more complex operations.
+    
+    let exti = unsafe { &(*pac::EXTI::ptr()) };
+    exti.pr.modify(|_, w| w.pr17().set_bit());
+
+    cortex_m::peripheral::NVIC::unpend(pac::Interrupt::RTCALARM);
+    // The clearing of the alarm flag in the main loop is preferred to avoid
+    // potential lock contention.
+}
 
 
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -7,6 +7,7 @@ use cortex_m::peripheral::syst;
 use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
 use rriv_board::hardware_error::{HardwareError};
+use stm32f1xx_hal::backup_domain::BackupDomain;
 use stm32f1xx_hal::time::{Hertz, MilliSeconds};
 use stm32f1xx_hal::timer::{CounterHz, CounterUs};
 
@@ -59,7 +60,7 @@ use rriv_board::{
 };
 
 use ds323x::{DateTimeAccess, Ds323x, NaiveDateTime};
-use stm32f1xx_hal::rtc::Rtc;
+use stm32f1xx_hal::rtc::{Rtc, RtcClkLse, RtcClkLsi};
 
 use one_wire_bus::{Address, OneWire, SearchState};
 
@@ -128,6 +129,7 @@ pub struct Board {
     one_wire_search_state: Option<SearchState>,
     pub watchdog: IndependentWatchdog,
     pub counter: CounterUs<TIM4>,
+    pub backup_domain: BackupDomain,
     pub hardware_errors: [HardwareError; 5]
 }
 
@@ -165,8 +167,14 @@ impl Board {
         let mut pwr = device_peripherals.PWR;
         let mut backup_domain = rcc.bkp.constrain(device_peripherals.BKP, &mut pwr);
 
-        let enter_standby =  1; // 0b1 & backup_domain.read_data_register_low(2);
+        let enter_standby = 0b1 & backup_domain.read_data_register_low(2);
         if enter_standby == 1 {
+            // clear the standby entry flag
+            backup_domain.write_data_register_low(2, 0b0);
+            
+            // get the seconds
+            let seconds = backup_domain.read_data_register_high(2);
+
             // do not disable the watchdog
             // and enter standby mode
 
@@ -187,14 +195,14 @@ impl Board {
             .freeze(&mut flash.acr);
 
 
-            let rtc = Rtc::new(device_peripherals.RTC, &mut backup_domain); // TODO: make sure LSE on and running?
-            Board::standby(10, rtc, core_peripherals);
+            let rtc = Rtc::new_lsi(device_peripherals.RTC, &mut backup_domain); // TODO: make sure LSE on and running?
+            Board::standby(seconds, rtc, core_peripherals);
         } 
         // otherwise do nothing
 
     }
 
-     fn standby(seconds: u32, mut rtc: Rtc, mut core_peripherals: pac::CorePeripherals){
+     fn standby(seconds: u16, mut rtc: Rtc<RtcClkLsi>, mut core_peripherals: pac::CorePeripherals){
          // Try Standby
 
           let (mut cs, mut sclk_led_enable, pwm_pin) = unsafe {
@@ -253,8 +261,96 @@ impl Board {
         exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
 
 
-        let alarm_time = start_sleep + seconds; // test with 2 sec
+        let alarm_time = start_sleep + seconds as u32; // test with 2 sec
         rtc.set_alarm(alarm_time); 
+
+        // turn off all the GPIO
+        // Get GPIO peripherals
+        let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+
+        let mut gpioa = device_peripherals_steal.GPIOA.split();
+        let mut gpiob = device_peripherals_steal.GPIOB.split();
+        let mut gpioc = device_peripherals_steal.GPIOC.split();
+        let mut gpiod = device_peripherals_steal.GPIOD.split();
+
+    // === Configure ALL GPIO pins to ANALOG mode ===
+    // This is critical for low power consumption in Standby mode
+    
+    // enable_3v: Pin<'C', 5>,
+    //   enable_5v: Pin<'B', 12>,
+
+    device_peripherals_steal.ADC1.cr2.modify(|_, w| w.adon().clear_bit());
+    device_peripherals_steal.RCC.apb2enr.modify(|_, w| w.adc1en().clear_bit());
+
+
+    // GPIOA (Pins 0-15)
+    let _pa0 = gpioa.pa0.into_analog(&mut gpioa.crl); // internal_adc1
+    let _pa1 = gpioa.pa1.into_push_pull_output(&mut gpioa.crl).set_high(); // enable_avdd
+    let _pa2 = gpioa.pa2.into_push_pull_output(&mut gpioa.crl).set_high(); // tx
+    let _pa3 = gpioa.pa3.into_pull_up_input(&mut gpioa.crl); // rx
+    let _pa4 = gpioa.pa4.into_push_pull_output(&mut gpioa.crl).set_high(); // external_adc_reset
+    let _pa5 = gpioa.pa5.into_push_pull_output(&mut gpioa.crl).set_low(); // spi1_sck
+    let _pa6 = gpioa.pa6.into_push_pull_output(&mut gpioa.crl).set_low(); // spi1_miso
+    let _pa7 = gpioa.pa7.into_push_pull_output(&mut gpioa.crl).set_low(); // spi1_mosi
+    let _pa8 = gpioa.pa8.into_push_pull_output(&mut gpioa.crh).set_low(); // rgb_red_and_wake_button
+    let _pa9 = gpioa.pa9.into_push_pull_output(&mut gpioa.crh).set_low(); // rgb_green_and_spi2_chip_select
+    let _pa10 = gpioa.pa10.into_push_pull_output(&mut gpioa.crh).set_low(); // rgb_blue
+    let _pa11 = gpioa.pa11.into_push_pull_output(&mut gpioa.crh).set_low(); // usb_n
+    let _pa12 = gpioa.pa12.into_push_pull_output(&mut gpioa.crh).set_low(); // usb_p
+    // let _pa13 = gpioa.pa13.into_analog(&mut gpioa.crh);  // SWDIO
+    // let _pa14 = gpioa.pa14.into_analog(&mut gpioa.crh);  // SWCLK
+    // let _pa15 = gpioa.pa15.into_analog(&mut gpioa.crh);
+    
+    // GPIOB (Pins 0-15)
+    let _pb0 = gpiob.pb0.into_analog(&mut gpiob.crl); // vin_measure
+    let _pb1 = gpiob.pb1.into_push_pull_output(&mut gpiob.crl).set_high(); // battery level mosfet
+    let _pb2 = gpiob.pb2.into_analog(&mut gpiob.crl); // boot pin
+    // let _pb3 = gpiob.pb3.into_analog(&mut gpiob.crl);
+    // let _pb4 = gpiob.pb4.into_analog(&mut gpiob.crl);
+    let _pb5 = gpiob.pb5.into_push_pull_output(&mut gpiob.crl).set_low(); // gpio2
+    let _pb6 = gpiob.pb6.into_pull_down_input(&mut gpiob.crl); // i2c1_scl
+    let _pb7 = gpiob.pb7.into_pull_down_input(&mut gpiob.crl); // i2c1_sda
+    let _pb8 = gpiob.pb8.into_push_pull_output(&mut gpiob.crh).set_low(); // gpio1
+    let _pb9 = gpiob.pb9.into_analog(&mut gpiob.crh); // unused
+    let _pb10 = gpiob.pb10.into_pull_down_input(&mut gpiob.crh); // i2c2_scl
+    let _pb11 = gpiob.pb11.into_pull_down_input(&mut gpiob.crh); // i2c2_sda
+    let _pb12 = gpiob.pb12.into_push_pull_output(&mut gpiob.crh).set_low(); // enable_5v
+    let _pb13 = gpiob.pb13.into_push_pull_output(&mut gpiob.crh).set_low(); // spi2_sck
+    let _pb14 = gpiob.pb14.into_push_pull_output(&mut gpiob.crh).set_low(); // spi2_miso
+    let _pb15 = gpiob.pb15.into_push_pull_output(&mut gpiob.crh).set_low(); // spi2_mosi
+    
+    // GPIOC (Pins 0-15) - Note: PC14/PC15 are typically LSE pins
+    let _pc0 = gpioc.pc0.into_analog(&mut gpioc.crl); // internal_adc5
+    let _pc1 = gpioc.pc1.into_analog(&mut gpioc.crl); // internal_adc4
+    let _pc2 = gpioc.pc2.into_analog(&mut gpioc.crl); // internal_adc3
+    let _pc3 = gpioc.pc3.into_analog(&mut gpioc.crl); // internal_adc2
+    let _pc4 = gpioc.pc4.into_analog(&mut gpioc.crl); // unused
+    let _pc5 = gpioc.pc5.into_push_pull_output(&mut gpioc.crl).set_low(); // enable_3v
+    let _pc6 = gpioc.pc6.into_push_pull_output(&mut gpioc.crl).set_high(); // exADC mosfet
+    let _pc7 = gpioc.pc7.into_push_pull_output(&mut gpioc.crl).set_low(); // duplicated? // unused
+    let _pc8 = gpioc.pc8.into_push_pull_output(&mut gpioc.crh).set_low(); // SD Card CS
+    let _pc9 = gpioc.pc9.into_analog(&mut gpioc.crh); // unused
+    let _pc10 = gpioc.pc10.into_push_pull_output(&mut gpioc.crh).set_low(); // gpio 8
+    let _pc11 = gpioc.pc11.into_push_pull_output(&mut gpioc.crh).set_low(); // gpio7
+    let _pc12 = gpioc.pc12.into_push_pull_output(&mut gpioc.crh).set_low(); // gpio6
+    // PC13, PC14, PC15 are special pins - usually reserved for LSE/RTC
+    // If you need to configure them as analog, do so carefully
+    let _pc13 = gpioc.pc13.into_push_pull_output(&mut gpioc.crh).set_low(); //enable HSE
+    // For PC14 and PC15 (LSE pins), DO NOT configure as analog if using LSE
+    let _pc14 = gpioc.pc14.into_push_pull_output(&mut gpioc.crh).set_low(); // Skip if using LSE
+    let _pc15 = gpioc.pc15.into_push_pull_output(&mut gpioc.crh).set_low();  // Skip if using LSE
+    
+    // Optional: Disable JTAG to free PA15, PB3, PB4 pins
+    // Use an AFIO instance to disable JTAG
+    let mut afio = device_peripherals_steal.AFIO.constrain();
+    let (pa15, pb3, pb4) = afio.mapr.disable_jtag(gpioa.pa15, gpiob.pb3, gpiob.pb4);
+    let _pb3 = pb3.into_push_pull_output(&mut gpiob.crl).set_low(); // gpio4
+    let _pb4 = pb4.into_push_pull_output(&mut gpiob.crl).set_low(); // gpio3
+    let _pa15 = pa15.into_analog(&mut gpioa.crh);
+
+    let _pd0 = gpiod.pd0.into_push_pull_output(&mut gpiod.crl).set_low(); // Skip if using LSE
+    let _pd1 = gpiod.pd1.into_push_pull_output(&mut gpiod.crl).set_low(); // Skip if using LSE
+    let _pd2 = gpiod.pd2.into_push_pull_output(&mut gpiod.crl).set_low(); 
 
         // Go into standby
         defmt::println!("go into stdby");
@@ -947,59 +1043,15 @@ impl RRIVBoard for Board {
         }
     }
 
-    fn standby(&mut self, minutes: u32){
-         // Try Standby
-        defmt::println!("try stdby"); defmt::flush();
-        let mut core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
+    fn standby(&mut self, interval: u32){
+        // minutes doesn't mean anything here yet.
+        // this is really about 'interval' and calculating the seconds until the next wake
+        // and then put them into the backup register and reset
+        let seconds = 20;
+        self.backup_domain.write_data_register_high(2, seconds);
+        self.backup_domain.write_data_register_low(2, 0b1);
+        SCB::sys_reset(); // reset so we can standby without the watchdog enabled.
 
-        NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  
-        NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); 
-        NVIC::mask(pac::Interrupt::USART2); 
-       
-        // This connects the RTC alarm event to the NVIC for wake-up
-        let exti = unsafe { &(*pac::EXTI::ptr()) };
-        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
-
-        // Enable interrupt on EXTI line 17
-        exti.imr.modify(|_, w| w.mr17().set_bit());     // Unmask interrupt
-        exti.emr.modify(|_, w| w.mr17().set_bit());     // Enable event (for wake from sleep)
-        exti.rtsr.modify(|_, w| w.tr17().set_bit());     // Rising edge trigger
-
-        // NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  // it's OK to wake up and do work?
-        // NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); // to keep interacting with the user?
-        // NVIC::mask(pac::Interrupt::USART2); // ok to wake up
-        unsafe {
-            NVIC::unmask(pac::Interrupt::RTCALARM);
-        }
-       
-        // set up wakeup
-        self.internal_rtc.set_time(0);
-        cortex_m::asm::delay(100);  // RTC sync
-        let start_sleep = self.internal_rtc.current_time();
-
-        // clear any pending
-        pac::NVIC::unpend(pac::Interrupt::RTCALARM);
-        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
-
-
-        let alarm_time = start_sleep + 10; // test with 2 sec
-        self.internal_rtc.set_alarm(alarm_time); 
-       
-        // Go into standby
-        defmt::println!("go into stdby");
-
-        let pwr = unsafe { &(*pac::PWR::ptr()) };
-        pwr.cr.modify(|_,w| w.pdds().set_bit());
-        pwr.cr.modify(|_,w| w.cwuf().set_bit());
-
-        core_peripherals.SCB.set_sleepdeep();
-
-        cortex_m::asm::dsb();
-        core_peripherals.SYST.disable_interrupt();
-        cortex_m::asm::wfi();
-
-        // should be in standby
-        defmt::println!("should not reach here");
     }
 
     fn sleep(&mut self, milliseconds: u64) {
@@ -1191,7 +1243,7 @@ fn usb_interrupt(cs: &CriticalSection) {
 }
 
 pub fn build() -> Board {
-    // Board::check_entry_standby();
+    Board::check_entry_standby();
     let mut board_builder = BoardBuilder::new();
     board_builder.setup();
     let board = board_builder.build();
@@ -1204,6 +1256,7 @@ pub struct BoardBuilder {
     // chip features
     pub delay: Option<DelayUs<TIM3>>,
     pub precise_delay: Option<PreciseDelayUs>,
+    pub backup_domain: Option<BackupDomain>,
 
     // pins groups
     pub gpio: Option<DynamicGpioPins>,
@@ -1245,6 +1298,7 @@ impl BoardBuilder {
             storage: None,
             watchdog: None,
             counter: None,
+            backup_domain: None,
             hardware_errors: [HardwareError::None; 5]
         }
     }
@@ -1297,6 +1351,7 @@ impl BoardBuilder {
             one_wire_search_state: None,
             watchdog: watchdog,
             counter: self.counter.unwrap(),
+            backup_domain: self.backup_domain.unwrap(),
             hardware_errors: self.hardware_errors
         }
     }
@@ -1779,6 +1834,7 @@ impl BoardBuilder {
 
         watchdog.feed();
 
+        self.backup_domain = Some(backup_domain);
         self.watchdog = Some(watchdog);
 
         defmt::println!("setting up RS485 serial b");

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1105,12 +1105,13 @@ impl RRIVBoard for Board {
         }
     }
 
-    fn standby(&mut self, interval: u32){
+    fn standby(&mut self, interval: u16){
         // minutes doesn't mean anything here yet.
         // this is really about 'interval' and calculating the seconds until the next wake
         // and then put them into the backup register and reset
-        let seconds = 500;
-        self.backup_domain.write_data_register_high(2, seconds);
+        let seconds = interval * 60;
+        // TODO: convert this into standard segemented hourly times using the exRTC
+        self.backup_domain.write_data_register_high(2, seconds as u16);
         self.backup_domain.write_data_register_low(2, 0b1);
         SCB::sys_reset(); // reset so we can standby without the watchdog enabled.
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -29,7 +29,7 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
 use stm32f1xx_hal::gpio::Pin;
-use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM6, USART2, USB};
+use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, SCB, TIM2, TIM4, TIM6, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
 use stm32f1xx_hal::{
@@ -151,6 +151,90 @@ impl Board {
 
     }
 
+    pub fn check_entry_standby(){
+        defmt::println!("check entry standby");
+        let core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
+        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+
+        // need to flash some LED or something
+       
+        
+        // mcu device registers
+        let rcc = device_peripherals.RCC.constrain();
+     
+        let mut pwr = device_peripherals.PWR;
+        let mut backup_domain = rcc.bkp.constrain(device_peripherals.BKP, &mut pwr);
+
+        let enter_standby =  1; // 0b1 & backup_domain.read_data_register_low(2);
+        if enter_standby == 1 {
+            // do not disable the watchdog
+            // and enter standby mode
+
+            // we don't need to do any clock stuff, we have just reset
+            // we don't need GPIO setup
+            // but we do need the internal RTC
+            // get the standby time from backup domain??
+            // it will need to be standby seconds, to account for seconds we are off
+            // calculated before going into standby using the exRTC
+            // clear enter_standby, so that the measurement loop will run on restart
+            let rtc = Rtc::new(device_peripherals.RTC, &mut backup_domain); // TODO: make sure LSE on and running?
+            Board::standby(10, rtc, core_peripherals);
+        } 
+        // otherwise do nothing
+
+    }
+
+     fn standby(seconds: u32, mut rtc: Rtc, mut core_peripherals: pac::CorePeripherals){
+         // Try Standby
+
+        defmt::println!("try stdby"); defmt::flush();
+
+        NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  
+        NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); 
+        NVIC::mask(pac::Interrupt::USART2); 
+       
+        // This connects the RTC alarm event to the NVIC for wake-up
+        let exti = unsafe { &(*pac::EXTI::ptr()) };
+        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
+
+        // Enable interrupt on EXTI line 17
+        exti.imr.modify(|_, w| w.mr17().set_bit());     // Unmask interrupt
+        exti.emr.modify(|_, w| w.mr17().set_bit());     // Enable event (for wake from sleep)
+        exti.rtsr.modify(|_, w| w.tr17().set_bit());     // Rising edge trigger
+
+        unsafe {
+            NVIC::unmask(pac::Interrupt::RTCALARM);
+        }
+       
+        // set up wakeup
+        rtc.set_time(0);
+        cortex_m::asm::delay(100);  // RTC sync
+        let start_sleep = rtc.current_time();
+
+        // clear any pending
+        pac::NVIC::unpend(pac::Interrupt::RTCALARM);
+        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
+
+
+        let alarm_time = start_sleep + seconds; // test with 2 sec
+        rtc.set_alarm(alarm_time); 
+       
+        // Go into standby
+        defmt::println!("go into stdby");
+
+        let pwr = unsafe { &(*pac::PWR::ptr()) };
+        pwr.cr.modify(|_,w| w.pdds().set_bit());
+        pwr.cr.modify(|_,w| w.cwuf().set_bit());
+
+        core_peripherals.SCB.set_sleepdeep();
+
+        cortex_m::asm::dsb();
+        core_peripherals.SYST.disable_interrupt();
+        cortex_m::asm::wfi();
+
+        // should be in standby
+        defmt::println!("should not reach here");
+    }
    
     pub fn enter_stop_mode(&mut self) {
         //           debug("setting up EXTI");
@@ -851,6 +935,61 @@ impl RRIVBoard for Board {
         }
     }
 
+    fn standby(&mut self, minutes: u32){
+         // Try Standby
+        defmt::println!("try stdby"); defmt::flush();
+        let mut core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
+
+        NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  
+        NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); 
+        NVIC::mask(pac::Interrupt::USART2); 
+       
+        // This connects the RTC alarm event to the NVIC for wake-up
+        let exti = unsafe { &(*pac::EXTI::ptr()) };
+        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
+
+        // Enable interrupt on EXTI line 17
+        exti.imr.modify(|_, w| w.mr17().set_bit());     // Unmask interrupt
+        exti.emr.modify(|_, w| w.mr17().set_bit());     // Enable event (for wake from sleep)
+        exti.rtsr.modify(|_, w| w.tr17().set_bit());     // Rising edge trigger
+
+        // NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  // it's OK to wake up and do work?
+        // NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); // to keep interacting with the user?
+        // NVIC::mask(pac::Interrupt::USART2); // ok to wake up
+        unsafe {
+            NVIC::unmask(pac::Interrupt::RTCALARM);
+        }
+       
+        // set up wakeup
+        self.internal_rtc.set_time(0);
+        cortex_m::asm::delay(100);  // RTC sync
+        let start_sleep = self.internal_rtc.current_time();
+
+        // clear any pending
+        pac::NVIC::unpend(pac::Interrupt::RTCALARM);
+        exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
+
+
+        let alarm_time = start_sleep + 10; // test with 2 sec
+        self.internal_rtc.set_alarm(alarm_time); 
+       
+        // Go into standby
+        defmt::println!("go into stdby");
+
+        let pwr = unsafe { &(*pac::PWR::ptr()) };
+        pwr.cr.modify(|_,w| w.pdds().set_bit());
+        pwr.cr.modify(|_,w| w.cwuf().set_bit());
+
+        core_peripherals.SCB.set_sleepdeep();
+
+        cortex_m::asm::dsb();
+        core_peripherals.SYST.disable_interrupt();
+        cortex_m::asm::wfi();
+
+        // should be in standby
+        defmt::println!("should not reach here");
+    }
+
     fn sleep(&mut self, milliseconds: u64) {
         // TODO: sleep mode won't work with independent watch dog, unless we can stop it.
         // EDIT: there is not alternative source for indep watchdog, it's always HSI
@@ -858,9 +997,13 @@ impl RRIVBoard for Board {
         // sleeping just needs to happen in units less that indep watchdog, but stop mode need restart and disable
         // if we wake from sleep should we go ahead and reset again to enable the watchdog during processing?
 
+
+       
+
+
+        // Sleep Mode
         // This connects the RTC alarm event to the NVIC for wake-up
         let exti = unsafe { &(*pac::EXTI::ptr()) };
-        // exti.pr.modify(|_, w| w.pr17().set_bit());
         exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
 
         // Enable interrupt on EXTI line 17
@@ -1036,6 +1179,7 @@ fn usb_interrupt(cs: &CriticalSection) {
 }
 
 pub fn build() -> Board {
+    Board::check_entry_standby();
     let mut board_builder = BoardBuilder::new();
     board_builder.setup();
     let board = board_builder.build();
@@ -1344,11 +1488,7 @@ impl BoardBuilder {
         let mut core_peripherals: pac::CorePeripherals = cortex_m::Peripherals::take().unwrap();
         let device_peripherals: pac::Peripherals = pac::Peripherals::take().unwrap();
 
-        let mut watchdog = IndependentWatchdog::new(device_peripherals.IWDG);
-        watchdog.stop_on_debug(&device_peripherals.DBGMCU, true);
-
-        watchdog.start(MilliSeconds::secs(WATCHDOG_TIMEOUT));
-        watchdog.feed();
+     
 
         // mcu device registers
         let rcc = device_peripherals.RCC.constrain();
@@ -1358,6 +1498,11 @@ impl BoardBuilder {
         let mut pwr = device_peripherals.PWR;
         let mut backup_domain = rcc.bkp.constrain(device_peripherals.BKP, &mut pwr);
 
+        let mut watchdog = IndependentWatchdog::new(device_peripherals.IWDG);
+        watchdog.stop_on_debug(&device_peripherals.DBGMCU, true);
+
+        watchdog.start(MilliSeconds::secs(WATCHDOG_TIMEOUT));
+        watchdog.feed();
 
         let uid = Uid::fetch();
         defmt::println!("uid: {:X}", uid.bytes());
@@ -1400,8 +1545,7 @@ impl BoardBuilder {
             usb_pins,
         ) = pin_groups::build(pins, &mut gpio_cr);
 
-        power_pins.enable_3v.set_high();
-        // delay.delay_ms(500_u32);
+        power_pins.enable_3v.set_high();        
         // power_pins.enable_3v.set_low();
         // delay.delay_ms(500_u32);
         // power_pins.enable_3v.set_high();

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -78,6 +78,7 @@ type RedLed = gpio::Pin<'A', 9, Output<OpenDrain>>;
 pub const HSE_MHZ: u32 = 8;
 pub const SYSCLK_MHZ: u32 = 48;
 pub const PCLK_MHZ: u32 = 24;
+pub const WATCHDOG_TIMEOUT: u32 = 6;
 
 #[allow(dead_code)]
 static WAKE_LED: Mutex<RefCell<Option<RedLed>>> = Mutex::new(RefCell::new(None));
@@ -1269,7 +1270,7 @@ impl BoardBuilder {
         let mut watchdog = IndependentWatchdog::new(device_peripherals.IWDG);
         watchdog.stop_on_debug(&device_peripherals.DBGMCU, true);
 
-        watchdog.start(MilliSeconds::secs(6));
+        watchdog.start(MilliSeconds::secs(WATCHDOG_TIMEOUT));
         watchdog.feed();
 
         // mcu device registers
@@ -1358,7 +1359,7 @@ impl BoardBuilder {
         let delay2: DelayUs<TIM2> = device_peripherals.TIM2.delay(&clocks);
         watchdog.start(MilliSeconds::secs(24));
         let storage = storage::build(spi2_pins, device_peripherals.SPI2, clocks, delay2);
-        watchdog.start(MilliSeconds::secs(6));
+        watchdog.start(MilliSeconds::secs(WATCHDOG_TIMEOUT));
         let storage = match storage {
             Ok(storage) => Some(storage),
             Err(hardware_error) => {

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -279,10 +279,7 @@ impl Board {
     // enable_3v: Pin<'C', 5>,
     //   enable_5v: Pin<'B', 12>,
 
-    // these didn't make a different
-    device_peripherals_steal.ADC1.cr2.modify(|_, w| w.adon().clear_bit());
-    device_peripherals_steal.RCC.apb2enr.modify(|_, w| w.adc1en().clear_bit());
-
+  
     // Enable backup domain write access (clears DBP bit in PWR_CR)
     // rcc_cfgr.bkp.enable(&mut rcc.apb1, &mut bkp);
 
@@ -371,8 +368,51 @@ impl Board {
     let _pd2 = gpiod.pd2.into_push_pull_output(&mut gpiod.crl).set_low(); 
 
 
+    // these didn't make a difference
+    device_peripherals_steal.ADC1.cr2.modify(|_, w| w.adon().clear_bit());
+    device_peripherals_steal.RCC.apb2enr.modify(|_, w| w.adc1en().clear_bit());
+
+
     // Disable both JTAG and SWD debug interface before Standby
-    afio.mapr.modify_mapr(|_, w| unsafe { w.swj_cfg().bits(0b010) }); // 0b010 = full disable
+    afio.mapr.modify_mapr(|_, w| unsafe { w.swj_cfg().bits(0b100) }); // 0b100 = full disable
+
+    let dbgmcu = unsafe { &(*pac::DBGMCU::ptr()) };
+    // Disable debug clocks in all low-power modes
+    dbgmcu.cr.modify(|_, w| {
+        unsafe { w.dbg_sleep().clear_bit()      // Disable debug in Sleep mode
+        .dbg_stop().clear_bit()       // Disable debug in Stop mode
+        .dbg_standby().clear_bit()    // Disable debug in Standby mode
+        .trace_mode().bits(0b00) }      // Disable trace pin assignment
+    });
+
+
+// 1. Disable all APB2 peripherals (GPIO, SPI1, ADC1, USART1, TIM1, etc.)
+device_peripherals_steal.RCC.apb2enr.modify(|_, w| w
+    .afioen().clear_bit()
+    .spi1en().clear_bit()
+    .usart1en().clear_bit()
+    .adc1en().clear_bit()
+    .tim1en().clear_bit()
+    // .gpioaen().clear_bit()
+    // .gpioben().clear_bit()
+    // .gpiocen().clear_bit()
+    // .gpioden().clear_bit()
+);
+
+// 2. Disable all APB1 peripherals (I2C, USART2/3, SPI2, TIM2-4, WWDG, PWR, BKP)
+device_peripherals_steal.RCC.apb1enr.modify(|_, w| w
+    .tim2en().clear_bit()
+    .tim3en().clear_bit()
+    .tim4en().clear_bit()
+    .wwdgen().clear_bit()
+    .usart2en().clear_bit()
+    .usart3en().clear_bit()
+    .i2c1en().clear_bit()
+    .i2c2en().clear_bit()
+    .spi2en().clear_bit()
+    // .pwren().clear_bit()   // Keep PWR enabled to enter standby
+    // .bkpcn().clear_bit()   // Backup interface clock
+);
 
         // Go into standby
         defmt::println!("go into stdby");

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1266,9 +1266,11 @@ impl BoardBuilder {
         let mut core_peripherals: pac::CorePeripherals = cortex_m::Peripherals::take().unwrap();
         let device_peripherals: pac::Peripherals = pac::Peripherals::take().unwrap();
 
-        let uid = Uid::fetch();
-        defmt::println!("uid: {:X}", uid.bytes());
-        self.uid = Some(uid.bytes());
+        let mut watchdog = IndependentWatchdog::new(device_peripherals.IWDG);
+        watchdog.stop_on_debug(&device_peripherals.DBGMCU, true);
+
+        watchdog.start(MilliSeconds::secs(6));
+        watchdog.feed();
 
         // mcu device registers
         let rcc = device_peripherals.RCC.constrain();
@@ -1278,7 +1280,15 @@ impl BoardBuilder {
         let mut pwr = device_peripherals.PWR;
         let mut backup_domain = rcc.bkp.constrain(device_peripherals.BKP, &mut pwr);
 
-        // get an unsafe handle on our the CS pin so we can flash it
+
+        let uid = Uid::fetch();
+        defmt::println!("uid: {:X}", uid.bytes());
+        self.uid = Some(uid.bytes());
+
+        watchdog.feed();
+
+        // get an unsafe handle on our CS pin so we can flash it
+        // and an unsafe hanlde on our PWM pin so we can pass to the config functions
         // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
         let mut cs = unsafe {
             let device_peripherals: pac::Peripherals = pac::Peripherals::steal();
@@ -1321,11 +1331,8 @@ impl BoardBuilder {
 
         let mut delay: DelayUs<TIM3> = device_peripherals.TIM3.delay(&clocks);
 
-        let mut watchdog = IndependentWatchdog::new(device_peripherals.IWDG);
-        watchdog.stop_on_debug(&device_peripherals.DBGMCU, true);
-
-        watchdog.start(MilliSeconds::secs(6));
         watchdog.feed();
+    
 
         BoardBuilder::setup_serial(
             serial_pins,

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -7,8 +7,8 @@ use cortex_m::peripheral::syst;
 use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
 use rriv_board::hardware_error::{HardwareError};
-use stm32f1xx_hal::time::MilliSeconds;
-use stm32f1xx_hal::timer::CounterUs;
+use stm32f1xx_hal::time::{Hertz, MilliSeconds};
+use stm32f1xx_hal::timer::{CounterHz, CounterUs};
 
 use core::fmt::{self};
 use core::mem;
@@ -29,7 +29,7 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
 use stm32f1xx_hal::gpio::Pin;
-use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, USART2, USB};
+use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM6, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
 use stm32f1xx_hal::{
@@ -278,7 +278,7 @@ impl RRIVBoard for Board {
         ) {
             Ok(message) => {
                 usb_serial_send(message, &mut self.delay);
-                defmt::println!("{}", message); // TODO: this uses format!
+                defmt::println!("{}", message); 
             }
             Err(e) => {
                 defmt::println!("format error {}", defmt::Debug2Format(&e));
@@ -382,15 +382,14 @@ impl RRIVBoard for Board {
         }
     }
 
-    // also crystal time, systick?
-
-    fn timestamp(&mut self) -> i64 {
-        return self.internal_rtc.current_time().into(); // internal RTC
+    // todo: different name.  this isn't a timestamp, it's just a seconds counter
+    fn seconds(&mut self) -> u32 {
+        return (self.get_millis() / 1000).into();
     }
 
     fn get_millis(&mut self) -> u32 {
         let millis = self.counter.now();
-        let millis = millis.ticks();  
+        let millis = millis.ticks() / 1000;   // this is natively a micros counter
         millis
     }
 
@@ -869,9 +868,9 @@ impl RRIVBoard for Board {
         exti.emr.modify(|_, w| w.mr17().set_bit());     // Enable event (for wake from sleep)
         exti.rtsr.modify(|_, w| w.tr17().set_bit());     // Rising edge trigger
 
-        // NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  // it's OK to wake up and do work
-        // NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); // to keep interacting with the user
-        NVIC::mask(pac::Interrupt::USART2);
+        // NVIC::mask(pac::Interrupt::USB_HP_CAN_TX);  // it's OK to wake up and do work?
+        // NVIC::mask(pac::Interrupt::USB_LP_CAN_RX0); // to keep interacting with the user?
+        // NVIC::mask(pac::Interrupt::USART2); // ok to wake up
         unsafe {
             NVIC::unmask(pac::Interrupt::RTCALARM);
         }
@@ -879,46 +878,73 @@ impl RRIVBoard for Board {
         // To detect if a debugger is attached to an STM32F103RB, you can check the DBGMCU_CR control register within the microcontroller.  Specifically, reading the bottom 3 bits of this register will indicate an active debug session, as these bits are set to 1 when a debugger attaches and default to 0 after a power-on reset.
 
         // if we are debugging, we need this.  but this interferes with actual low power modes
+        // actually but debugger itself is supposed to set these??
         // #[cfg(debug_assertions)]
         // {
-            let dbgmcu = unsafe { &(*pac::DBGMCU::ptr()) };
-            dbgmcu.cr.modify(|_, w| w.dbg_sleep().set_bit());  // Enable debug in sleep
+            // let dbgmcu = unsafe { &(*pac::DBGMCU::ptr()) };
+            // dbgmcu.cr.modify(|_, w| w.dbg_sleep().set_bit());  // Enable debug in sleep
         // }
 
-        let mut remainder: u32 = milliseconds;
+        let mut remainder: u64 = milliseconds;
         
         defmt::println!("try sleep {}", milliseconds);
+            usb_serial_send("try sleep\n", &mut self.delay);
 
-        let macrosleep_interval_s = WATCHDOG_TIMEOUT - 2;
-        while remainder > macrosleep_interval_s * 1000 {
+        self.internal_rtc.select_frequency(Hertz::Hz(1000));  // the crystal is 32kHZ, so setting this to 32 gives millisecond behavior
+        let macrosleep_interval_ms: u32 = (WATCHDOG_TIMEOUT - 2) * 1000;
+        while remainder > 0{
             self.watchdog.feed(); 
-            
-            // self.internal_rtc.set_time(0);
-            // cortex_m::asm::delay(100);  // RTC sync
+            self.internal_rtc.set_time(0);
+            cortex_m::asm::delay(100);  // RTC sync
+            let start_sleep = self.internal_rtc.current_time();
+
             pac::NVIC::unpend(pac::Interrupt::RTCALARM);
             exti.pr.modify(|_, w| w.pr17().set_bit());       // Write 1 to clear
-            self.internal_rtc.set_alarm(self.internal_rtc.current_time() + macrosleep_interval_s); // sleep in units of WATCHDOG_TIMEOUT - 2, triggers on the actual time
-            defmt::println!("will sleep {}", self.internal_rtc.current_time() );  
+
+            let interval = if remainder > macrosleep_interval_ms.into() {
+                macrosleep_interval_ms
+            } else {
+                remainder as u32
+            };
+
+            let alarm_time = start_sleep + interval;
+            self.internal_rtc.set_alarm(alarm_time); // sleep in units of WATCHDOG_TIMEOUT - 2, triggers on the actual time
+            defmt::println!("will sleep {} {}, {}", remainder, alarm_time, self.internal_rtc.current_time() );  
+            usb_serial_send("will sleep\n", &mut self.delay);
+            // self.usb_serial_send(format_args!("{}\n", interval));
 
             cortex_m::asm::dsb();
 
             let mut core_peripherals: pac::CorePeripherals = unsafe { cortex_m::Peripherals::steal() };
             core_peripherals.SYST.disable_interrupt();
 
-            cortex_m::asm::wfi();
+            while self.internal_rtc.current_time() < alarm_time { // loop handles wakes from USB
+                defmt::println!("{}", self.internal_rtc.current_time());
+                cortex_m::asm::wfi();
+                // self.error_alarm();
+            }
 
             core_peripherals.SYST.enable_interrupt();
 
-            // self.internal_rtc.clear_alarm_flag();
+            cortex_m::asm::isb();
+
+            self.internal_rtc.clear_alarm_flag();
             defmt::println!("did sleep {}", self.internal_rtc.current_time() );  defmt::flush();
-            usb_serial_send("sleeping", &mut self.delay);
-            remainder = remainder - macrosleep_interval_s * 1000;
+            usb_serial_send("did sleep\n", &mut self.delay);
+            let slept = (self.internal_rtc.current_time() - start_sleep) as u64;
+            remainder = if slept < remainder {
+                remainder - slept
+            } else {
+                0
+            }
 
         }
         self.watchdog.feed(); 
-        defmt::println!("woke from sleep");
-        // handle the rest of the sleep, the remaining milliseconds
+        defmt::println!("woke from sleep"); defmt::flush();
+
         unsafe {
+            NVIC::unmask(pac::Interrupt::USB_HP_CAN_TX);  
+            NVIC::unmask(pac::Interrupt::USB_LP_CAN_RX0);
             NVIC::unmask(pac::Interrupt::USART2);
         }
         NVIC::mask(pac::Interrupt::RTCALARM);
@@ -1589,7 +1615,7 @@ impl BoardBuilder {
         self.delay = Some(delay);
         self.precise_delay = Some(precise_delay);
 
-        // the millis counter
+        // the millis counter, has to be a micros and then scale down
         let mut counter: CounterUs<TIM4> = device_peripherals.TIM4.counter_us(&clocks);
         match counter.start(2.micros()) {
             Ok(_) => defmt::println!("Millis counter start ok"),

--- a/scripts/attach.sh
+++ b/scripts/attach.sh
@@ -1,6 +1,6 @@
 probe-rs attach board/target/thumbv7m-none-eabi/debug/app \
         --chip STM32F103RE  \
         --protocol swd \
-        --allow-erase-all \
-        --chip-erase
+        --no-catch-hardfault \
+        --no-catch-reset
 

--- a/src/datalogger/src/drivers/battery_level.rs
+++ b/src/datalogger/src/drivers/battery_level.rs
@@ -1,0 +1,89 @@
+use crate::sensor_name_from_type_id;
+
+use super::types::*;
+use serde_json::json;
+
+pub struct BatteryLevel {
+    general_config: SensorDriverGeneralConfiguration,
+    special_config: EmptySpecialConfiguration,
+    measured_parameter_values: [f64; 1],
+}
+
+impl SensorDriver for BatteryLevel {
+    fn get_configuration_json(&mut self) -> serde_json::Value {
+        
+        let mut sensor_id = self.get_id();
+        let sensor_id = match util::str_from_utf8(&mut sensor_id) {
+            Ok(sensor_id) => sensor_id,
+            Err(_) => "Invalid",
+        };
+
+        let mut sensor_name = sensor_name_from_type_id(self.get_type_id().into());
+        let sensor_name = match util::str_from_utf8(&mut sensor_name) {
+            Ok(sensor_name) => sensor_name,
+            Err(_) => "Invalid",
+        };
+
+        json!({
+           "id" : sensor_id,
+           "type" : sensor_name
+        })
+    }
+
+    #[allow(unused)]
+    fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+    }
+ 
+    getters!();
+
+    fn get_measured_parameter_count(&mut self) -> usize {
+        return 1;
+    }
+
+    fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
+        return Ok(self.measured_parameter_values[index]);
+    }
+
+    fn get_measured_parameter_identifier(&mut self, _index: usize) -> [u8; 16] {
+
+        let identifier: &str = "V";
+        let mut buf: [u8; 16] = [0_u8; 16];     
+        for i in 0..identifier.len() {
+            buf[i] = identifier.as_bytes()[i];
+        }
+        return buf;
+    }
+
+    fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        defmt::println!("get the battery level");
+        let value = board.get_battery_level();
+        defmt::println!("got the battery level");
+        self.measured_parameter_values[0] = value.into();
+        defmt::println!("stored the battery level");
+    }
+
+
+
+}
+
+impl BatteryLevel {
+    // pub fn new(general_config: SensorDriverGeneralConfiguration, special_config_bytes: &[u8; rriv_board::EEPROM_SENSOR_SPECIAL_SETTINGS_SIZE]) -> Self {
+
+    //     let special_config = GenericAnalogSpecialConfiguration::new_from_bytes(special_config_bytes);
+    //     GenericAnalog {
+    //         general_config,
+    //         special_config
+    //     }
+    // }
+
+    pub fn new(
+        general_config: SensorDriverGeneralConfiguration,
+        special_config: EmptySpecialConfiguration,
+    ) -> Self {
+        BatteryLevel {
+            general_config,
+            special_config,
+            measured_parameter_values: [0.0; 1],
+        }
+    }
+}

--- a/src/datalogger/src/drivers/mod.rs
+++ b/src/datalogger/src/drivers/mod.rs
@@ -17,4 +17,5 @@ pub mod adc_temperature;
 pub mod resources;
 pub mod modbus;
 pub mod mhz9041a;
+pub mod battery_level;
 

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -6,11 +6,61 @@ use super::mcp9808::*;
 
 use super::types::*;
 use alloc::boxed::Box;
+use bitfield_struct::bitfield;
 use rtt_target::rprint;
 use serde_json::json;
 
 const MULTIPLEXER_ADDRESS: u8 = 0x70;
 // TODO: calibration offsets for all 6 sensors need to be stored and loaded into this driver, and written to EEPROM.
+
+enum MeasurementOutputMode {
+    Raw,  // default
+    Calibrated,
+    RawAndCalibrated,
+}
+
+#[bitfield(u8)] 
+struct MeasurementOutputs {
+    #[bits(1, default = true)]
+    raw: bool,
+
+    #[bits(1, default = false)]
+    calibrated: bool,
+
+    #[bits(1, default = false)]
+    differences: bool, // not supported yet
+
+    #[bits(1, default = false)]
+    vector: bool, // not supported yet
+
+    #[bits(4, access = RO, default = 0)]
+    reserved: u8,
+}
+
+impl MeasurementOutputs {
+    fn get_mode(&self) -> MeasurementOutputMode {
+        if self.raw() && self.calibrated() {
+            MeasurementOutputMode::RawAndCalibrated
+        } else if self.raw() {
+            MeasurementOutputMode::Raw
+        } else if self.calibrated() {
+            MeasurementOutputMode::Calibrated
+        } else {
+            MeasurementOutputMode::Raw
+        }
+    }
+
+    fn total_parameter_count(&self, channels: usize, sensors: usize) -> usize{
+        let mut count = 0;
+        if self.raw() {
+            count = count + channels * sensors;
+        }
+        if self.calibrated() {
+            count = count + channels * sensors;
+        }
+        count
+    }
+}
 
 #[derive(Copy, Clone)]
 pub struct RingMuxTemperatureDriverSpecialConfiguration {
@@ -18,6 +68,7 @@ pub struct RingMuxTemperatureDriverSpecialConfiguration {
     sensors: usize,
     calibration_offset: [i16; 8], // 16
     address_offset: u8, // 1
+    measurement_outputs: MeasurementOutputs
 }
 
 impl RingMuxTemperatureDriverSpecialConfiguration {
@@ -63,11 +114,42 @@ impl RingMuxTemperatureDriverSpecialConfiguration {
             }
         }
 
+        let mut measurement_outputs = MeasurementOutputs::new();
+        match &value["measurements_raw"] {
+            serde_json::Value::Bool(value) => {
+                measurement_outputs.set_raw(*value);
+            }
+            _ => {}
+        }
+
+        match &value["measurements_calibrated"] {
+            serde_json::Value::Bool(value) => {
+                measurement_outputs.set_calibrated(*value);
+            }
+            _ => {}
+        }
+
+        match &value["measurements_differences"] {
+            serde_json::Value::Bool(value) => {
+                measurement_outputs.set_differences(*value);
+            }
+            _ => {}
+        }
+
+        match &value["measurements_vector"] {
+            serde_json::Value::Bool(value) => {
+                measurement_outputs.set_vector(*value);
+            }
+            _ => {}
+        }
+
+
         Ok ( Self {
             channels: channels,
             sensors: sensors,
             calibration_offset: [0; TEMPERATURE_SENSORS_ON_RING],
             address_offset: 0,
+            measurement_outputs: measurement_outputs
         } ) // Just using default address offset of 0 for now, need to optionally read from JSON
     }
 
@@ -248,7 +330,11 @@ impl SensorDriver for RingMuxTemperatureDriver {
             "type" : sensor_name,
             "calibration_offset": self.special_config.calibration_offset,
             "channels": self.special_config.channels,
-            "sensors": self.special_config.sensors
+            "sensors": self.special_config.sensors,
+            "measurements_raw" : self.special_config.measurement_outputs.raw(),
+            "measurements_calibrated" : self.special_config.measurement_outputs.calibrated(),
+            "measurements_differences" : self.special_config.measurement_outputs.differences(),
+            "measurements_vector" : self.special_config.measurement_outputs.vector(),
         })
     }
 
@@ -265,20 +351,45 @@ impl SensorDriver for RingMuxTemperatureDriver {
         if self.special_config.channels > 0 {
             channels_used = self.special_config.channels;
         }
-        self.special_config.sensors * 2 * channels_used
+        
+        self.special_config.measurement_outputs.total_parameter_count(channels_used, self.special_config.sensors)
+
+        // let mut count = 0;
+        
+        // if self.special_config.measurement_outputs.raw() {
+        //     count = count + channels_used;
+        // }
+
+        // if self.special_config.measurement_outputs.calibrated() {
+        //     count = count + channels_used;
+        // }
+
+        // count
     }
 
     fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
-        if self.measured_parameter_values[index] == f64::MAX {
+        
+        let index_mapped = match self.special_config.measurement_outputs.get_mode() {
+            MeasurementOutputMode::Raw => index * 2,
+            MeasurementOutputMode::Calibrated => index * 2 + 1,
+            MeasurementOutputMode::RawAndCalibrated => index,
+        };
+
+        if self.measured_parameter_values[index_mapped] == f64::MAX {
             Err(())
         } else {
-            Ok(self.measured_parameter_values[index])
+            Ok(self.measured_parameter_values[index_mapped])
         }
     }
 
     fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
-        let sensor_index = (index / 2) % self.special_config.sensors;
-        let parameter_index = index % 2;
+
+        let (sensor_index, parameter_index) = match self.special_config.measurement_outputs.get_mode() {
+            MeasurementOutputMode::Raw => ( index % self.special_config.sensors, 0),
+            MeasurementOutputMode::Calibrated => ( index % self.special_config.sensors , 1),
+            MeasurementOutputMode::RawAndCalibrated => ( (index / 2) % self.special_config.sensors, index % 2)
+        };
+        
         let buf =
             self.sensor_drivers[sensor_index].get_measured_parameter_identifier(parameter_index);
 

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -362,7 +362,7 @@ impl SensorDriver for TimedSwitch2 {
                 } 
             }
             // end of on_time (outer cycle)
-            if timestamp - self.special_config.on_time_s as u32 > self.last_state_updated_at {
+            if timestamp > self.last_state_updated_at + self.special_config.on_time_s as u32 {
                 defmt::println!("state is 1, toggle triggered");
                 toggle_state = true;
                 gpio_state = false;

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -247,7 +247,7 @@ pub struct TimedSwitch2 {
     general_config: SensorDriverGeneralConfiguration,
     special_config: TimedSwitch2SpecialConfiguration,
     state: u8, // 0: off, 1: on, other: invalid for now
-    last_state_updated_at: i64,
+    last_state_updated_at: u32,
     duty_cycle_state: bool,
     last_duty_cycle_update: u32,
     duty_cycle_on_time: u32,
@@ -280,7 +280,7 @@ impl SensorDriver for TimedSwitch2 {
             false => 0,
         };
         board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
-        let timestamp = board.timestamp();
+        let timestamp = board.seconds();
         self.last_state_updated_at = timestamp;
         self.duty_cycle_state = self.state == 1;
         let millis = board.millis();
@@ -321,14 +321,14 @@ impl SensorDriver for TimedSwitch2 {
     }
 
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        let timestamp = board.timestamp();
+        let timestamp = board.seconds();
         let millis = board.millis();
 
         let mut gpio_state = false;
         let mut toggle_state = false;
         if self.state == 0 {
             // heater is off
-            if timestamp - self.special_config.off_time_s as i64 > self.last_state_updated_at {
+            if timestamp - self.special_config.off_time_s as u32 > self.last_state_updated_at {
                 defmt::println!("state is 0, toggle triggered");
                 toggle_state = true;
                 gpio_state = true;
@@ -362,7 +362,7 @@ impl SensorDriver for TimedSwitch2 {
                 } 
             }
             // end of on_time (outer cycle)
-            if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
+            if timestamp - self.special_config.on_time_s as u32 > self.last_state_updated_at {
                 defmt::println!("state is 1, toggle triggered");
                 toggle_state = true;
                 gpio_state = false;

--- a/src/datalogger/src/drivers/types.rs
+++ b/src/datalogger/src/drivers/types.rs
@@ -20,6 +20,20 @@ pub struct SensorDriverGeneralConfiguration {
 #[allow(dead_code)]
 pub struct EmptySpecialConfiguration {}
 
+impl EmptySpecialConfiguration {
+    pub fn parse_from_values(_value: serde_json::Value) -> Result<EmptySpecialConfiguration, &'static str> {
+        Ok(Self {})
+    }
+
+    pub fn new_from_bytes(
+        bytes: [u8; SENSOR_SETTINGS_PARTITION_SIZE],
+    ) -> EmptySpecialConfiguration {
+        EmptySpecialConfiguration {}
+    }
+}
+
+
+
 impl SensorDriverGeneralConfiguration {
     pub fn new(id: [u8; 6], sensor_type_id: u16) -> SensorDriverGeneralConfiguration {
         Self {

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -485,7 +485,11 @@ impl DataLogger {
                 for j in 0..driver.get_measured_parameter_count(){
                         match driver.get_measured_parameter_value(j) {
                         Ok(value) => {
-                            values[k] = (value * 100_f64) as i16;
+                            if value < 100_f64 {
+                                values[k] = (value * 100_f64) as i16;
+                            } else {
+                                values[k] = value as i16;
+                            }
                             k = k + 1;
                         }
                         Err(_) => defmt::println!("error reading value"),

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -355,7 +355,7 @@ impl DataLogger {
                 // process telemetry
                 // process actuators
 
-                if board.timestamp()
+                if board.epoch_timestamp()
                     >= self.last_interactive_log_time
                         + self.settings.interactive_logging_interval as i64
                 {
@@ -380,7 +380,7 @@ impl DataLogger {
                         self.write_raw_measurement_to_storage(board);
                     }                    
 
-                    self.last_interactive_log_time = board.timestamp();
+                    self.last_interactive_log_time = board.epoch_timestamp();
                     defmt::trace!("interactive measurement completed");
 
                 }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -360,23 +360,28 @@ impl DataLogger {
                 {
                     // process a single measurement
                     // is this called a 'single measurement cycle' ?
+                    defmt::trace!("interactive measurement");
 
                     self.process_errors(board);
-
+                    defmt::trace!("measure sensor values");
                     self.measure_sensor_values(board); // measureSensorValues(false);
+                    defmt::trace!("got sensor values");
 
                     self.relay_modbus_message(board);
 
-
+                    defmt::trace!("try to write to storage");
                     self.write_last_measurement_to_serial(board); //outputLastMeasurement();
                                                                   // Serial2.print(F("CMD >> "));
                                                                   // writeRawMeasurementToLogFile();
                                                                   // fileSystemWriteCache->flushCache();
+                    defmt::trace!("wrote to storage");
                     if self.settings.toggles.enable_interactive_logging() {
                         self.write_raw_measurement_to_storage(board);
                     }                    
 
                     self.last_interactive_log_time = board.timestamp();
+                    defmt::trace!("interactive measurement completed");
+
                 }
                 
                 self.process_telemetry(board);
@@ -541,7 +546,9 @@ impl DataLogger {
     }
 
     fn measure_sensor_values(&mut self, board: &mut impl rriv_board::RRIVBoard) {
+        defmt::trace!("msv");
         for i in 0..self.sensor_drivers.len() {
+            defmt::trace!("{}", i);
             if let Some(ref mut driver) = self.sensor_drivers[i] {
                 driver.take_measurement(board);
             }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -383,7 +383,6 @@ impl DataLogger {
                     self.last_interactive_log_time = board.epoch_timestamp();
                     defmt::trace!("interactive measurement completed");
 
-                    board.sleep(2000);
                 }
                 
                 self.process_telemetry(board);

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -288,6 +288,7 @@ impl DataLogger {
     }
 
     pub fn run_loop_iteration(&mut self, board: &mut impl RRIVBoard) {
+
         //
         // Process incoming commands
         //
@@ -401,14 +402,9 @@ impl DataLogger {
                     self.process_telemetry(board);
 
                     //     // go to sleep until the next in interval (in minutes)
-                    let mut slept = 0u64;
-                    while slept < (self.settings.sleep_interval as u64) * 1000u64 * 60u64 {
-                        // TODO: allow using interactive_logging_interval here for testing
-                        board.delay_ms(2000);
-                        board.sleep(); // TODO: this just feeds the watchdog for now
-                        slept = slept + 2000;
-                    }
-
+                    let milliseconds = (self.settings.sleep_interval as u64) * 60u64 * 1000u64;
+                    board.sleep(milliseconds);
+                  
                     //     // start the next measurement cycle
                     self.initialize_measurement_cycle();
                 }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -518,7 +518,7 @@ impl DataLogger {
         }
         
         if modbus_rtu_ready {
-            self.modbus_telemeter.as_mut().unwrap().transmit(board, &values);
+            // self.modbus_telemeter.as_mut().unwrap().transmit(board, &values);
         }
 
 
@@ -1310,14 +1310,14 @@ impl DataLogger {
             }
         }
 
-        if let Some(enable_modbus_rtu) = &values.enable_modbus_rtu {
-            if self.settings.toggles.enable_modbus_rtu() != *enable_modbus_rtu {
-               match self.set_up_modbus_rtu(*enable_modbus_rtu) {
-                    Ok(_) => {},
-                    Err(error) => {return Err(error);}, 
-                }
-            }
-        }
+        // if let Some(enable_modbus_rtu) = &values.enable_modbus_rtu {
+        //     if self.settings.toggles.enable_modbus_rtu() != *enable_modbus_rtu {
+        //        match self.set_up_modbus_rtu(*enable_modbus_rtu) {
+        //             Ok(_) => {},
+        //             Err(error) => {return Err(error);}, 
+        //         }
+        //     }
+        // }
 
         if let Some(enable_interactive_logging) = &values.interactive_logging {
             if *enable_interactive_logging {

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -383,8 +383,6 @@ impl DataLogger {
                     self.last_interactive_log_time = board.epoch_timestamp();
                     defmt::trace!("interactive measurement completed");
 
-                    board.standby(15); // enter into standby mode to wake on the next quarter hour
-
                 }
                 
                 self.process_telemetry(board);
@@ -403,12 +401,10 @@ impl DataLogger {
 
                     self.process_telemetry(board);
 
-                    //     // go to sleep until the next in interval (in minutes)
-                    let milliseconds = (self.settings.sleep_interval as u64) * 60u64 * 1000u64;
-                    board.sleep(milliseconds);
-                  
-                    //     // start the next measurement cycle
-                    self.initialize_measurement_cycle();
+                    // go into standby until the next interval (in minutes)
+                    board.standby(self.settings.sleep_interval);
+                    panic!("unreachable: after standby");
+
                 }
             }
             DataLoggerMode::HibernateUntil => {

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -383,6 +383,7 @@ impl DataLogger {
                     self.last_interactive_log_time = board.epoch_timestamp();
                     defmt::trace!("interactive measurement completed");
 
+                    board.sleep(2000);
                 }
                 
                 self.process_telemetry(board);

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -383,6 +383,8 @@ impl DataLogger {
                     self.last_interactive_log_time = board.epoch_timestamp();
                     defmt::trace!("interactive measurement completed");
 
+                    board.standby(15); // enter into standby mode to wake on the next quarter hour
+
                 }
                 
                 self.process_telemetry(board);

--- a/src/datalogger/src/registry.rs
+++ b/src/datalogger/src/registry.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use crate::drivers::{ types::{SensorDriver, SensorDriverGeneralConfiguration, SENSOR_SETTINGS_PARTITION_SIZE}};
 
 
-const SENSOR_NAMES: [&str; 14] = [
+const SENSOR_NAMES: [&str; 15] = [
     "no_match",
     "generic_analog",
     "atlas_ec",
@@ -16,7 +16,8 @@ const SENSOR_NAMES: [&str; 14] = [
     "ring_w_mux",
     "ring_temp_sim",
     "groundwater_rtu",
-    "mhz9041a"
+    "mhz9041a",
+    "battery_level"
 ];
 
 pub fn sensor_type_id_from_name(name: &str) -> Result<u16, ()> {
@@ -134,6 +135,10 @@ pub fn get_registry() -> [DriverCreateFunctions; 256] {
     driver_create_functions[13] = Some(driver_create_functions!(
         crate::drivers::mhz9041a::MHZ9041ADriver,
         crate::drivers::mhz9041a::MHZ9041ADriverSpecialConfiguration
+    ));
+    driver_create_functions[14] = Some(driver_create_functions!(
+        crate::drivers::battery_level::BatteryLevel,
+        crate::drivers::types::EmptySpecialConfiguration
     ));
 
     driver_create_functions

--- a/src/datalogger/src/services/usart_service.rs
+++ b/src/datalogger/src/services/usart_service.rs
@@ -12,7 +12,7 @@ static mut COMMAND: [u8; USART_BUFFER_SIZE] = [0u8; USART_BUFFER_SIZE];
 static mut MESSAGE_DATA: MessageData = MessageData::default();  // TODO: This can be owned by USARTCharacterProcessor, doesn't need to be static
 
 pub struct MessageData {
-    buffer: [[u8; USART_BUFFER_SIZE]; USART_BUFFER_NUM],  // The buffer can just be contiguous memory, we can raise command avialable by detected \r
+    buffer: [[u8; USART_BUFFER_SIZE]; USART_BUFFER_NUM],  // TODO: The buffer can just be contiguous memory, we can raise command avialable by detected \r
     cur: usize,
     end: usize,
     command_pos: usize,

--- a/src/datalogger/src/telemetry/codecs/naive_codec.rs
+++ b/src/datalogger/src/telemetry/codecs/naive_codec.rs
@@ -24,7 +24,7 @@ pub fn encode( timestamp: i64,
       // rprintln!("{:?}", (i * 4 + 8)..(i * 4 + 12));
       let byte_position = 8 + i * BYTES_PER_VALUE;
       bytes[(byte_position)..(byte_position + BYTES_PER_VALUE)].copy_from_slice(&value_bytes);
-      defmt::println!("{:X}", value_bytes);
+      defmt::debug!("{} {:X}", values[i], value_bytes);
     }
     
     defmt::println!("{:X}", bytes);

--- a/src/datalogger/src/telemetry/telemeters/lorawan.rs
+++ b/src/datalogger/src/telemetry/telemeters/lorawan.rs
@@ -59,8 +59,8 @@ impl RakWireless3172Step {
 
 pub struct RakWireless3172 {
     telemetry_step: RakWireless3172Step,
-    usart_send_time: i64,
-    last_transmission: i64,
+    usart_send_time: u32,
+    last_transmission: u32,
     watch: bool,
 }
 
@@ -85,7 +85,7 @@ impl RakWireless3172 {
     fn send_and_increment_step(&mut self, board: &mut dyn RRIVBoard, message: &str) {
         let prepared_message = format_args!("{}\r\n", message);
         usart_service::format_and_send(board, prepared_message);        
-        self.usart_send_time = board.timestamp();
+        self.usart_send_time = board.seconds();
         self.telemetry_step = self.telemetry_step.next();
         defmt::println!("trying telemetry step {}", self.telemetry_step as u8);
     }
@@ -128,7 +128,7 @@ impl RakWireless3172 {
 
         // need to check for a timeout here
         // defmt::println!("no message, checking timeout");
-        if board.timestamp() - self.usart_send_time > 2 {
+        if board.seconds() - self.usart_send_time > 2 {
             defmt::println!("timed out, going to step 0");
             self.telemetry_step = RakWireless3172Step::Begin;
         }
@@ -167,7 +167,7 @@ impl RakWireless3172 {
         } {}
 
         // checking timeout if we didn't return above
-        if board.timestamp() - self.usart_send_time > 120 {
+        if board.seconds() - self.usart_send_time > 120 {
             // could power cycle here, but consider effect on intADC
             self.telemetry_step = RakWireless3172Step::Begin;
         }
@@ -312,7 +312,7 @@ impl Telemeter for RakWireless3172 {
 
         let args = format_args!("AT+SEND={}:{}\r\n", size, s.as_str()); 
         usart_service::format_and_send(board, args);
-        self.last_transmission = board.timestamp();
+        self.last_transmission = board.seconds();
     }
 
     fn ready_to_transmit(&mut self, board: &mut dyn RRIVBoard) -> bool {
@@ -320,7 +320,7 @@ impl Telemeter for RakWireless3172 {
             return false;
         }
 
-        if board.timestamp() < self.last_transmission + 10 {
+        if board.seconds() < self.last_transmission + 10 {
             false
         } else {
             true


### PR DESCRIPTION
- **feat: allow selection of output parameters in ring mux driver**
- **feat: move the watchdog earlier**
- **fix: move the enable 3v so we dont crash stuff**
- **feat: add battery level sensor driver**
- **fix: improve battery level aquisition**
- **chore: use new hard fault defaults for probe-rs attach**
- **fix: implement the empty special settings partition**
- **feat: modify telemetry to transmit values 100-9999 correctly**
- **fix: comment out incomplete modbus implementation**
- **fix: add some filtered logs**
- **chore: update TODO**
- **fix: factor a const for watchdog timout**
- **feat: working low power wfi sleep**
- **feat: implement sleep as milliseconds**
