### PR TITLE
modbus-wip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.5](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.4...v1.14.0-preview-sdi12-pwm-groundwater.5) (2026-04-23)
+
+
+### Bug Fixes
+
+* increase size of command buffer ([c6e62c7](https://github.com/rrivirr/rriv-firmware/commit/c6e62c7dec883904f78a643d5f39608a0603f3b6))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.4](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.3...v1.14.0-preview-sdi12-pwm-groundwater.4) (2026-04-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.8](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.7...v1.14.0-preview-sdi12-pwm-groundwater.8) (2026-04-29)
+
+
+### Bug Fixes
+
+* attempt at pwm fix ([2acc85f](https://github.com/rrivirr/rriv-firmware/commit/2acc85f2754fa3bdb12d573e61ad12a54db651e8))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.7](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.6...v1.14.0-preview-sdi12-pwm-groundwater.7) (2026-04-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.15](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.14...v1.14.0-preview-sdi12-pwm-groundwater.15) (2026-05-21)
+
+
+### Features
+
+* move the watchdog earlier ([1e5d4cc](https://github.com/rrivirr/rriv-firmware/commit/1e5d4ccbf41073c9a0b44212c247eff03f9e7ad4))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.14](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.13...v1.14.0-preview-sdi12-pwm-groundwater.14) (2026-04-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.11](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.10...v1.14.0-preview-sdi12-pwm-groundwater.11) (2026-04-29)
+
+
+### Bug Fixes
+
+* also apply hardware pwm in setup ([fad30dd](https://github.com/rrivirr/rriv-firmware/commit/fad30dd6ae7a070f9cd2adf90a717f6f00c903ce))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.10](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.9...v1.14.0-preview-sdi12-pwm-groundwater.10) (2026-04-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.3](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.2...v1.14.0-preview-sdi12-pwm-groundwater.3) (2026-04-21)
+
+
+### Bug Fixes
+
+* add watch mode data for sdi12 ([fd13486](https://github.com/rrivirr/rriv-firmware/commit/fd13486bfbf1e66444e8ede29fe444b724f68ef7))
+* clear data received each time we query ([5a0390d](https://github.com/rrivirr/rriv-firmware/commit/5a0390d9684f4d539b563d3f38f4e72878b8cfe5))
+* commented usb serial send ([118a6d0](https://github.com/rrivirr/rriv-firmware/commit/118a6d0e038a3cd12525feff4f4c94ac9d3faab6))
+* get rid of rtt ([ed5daa0](https://github.com/rrivirr/rriv-firmware/commit/ed5daa041622820c0fb96b69503a5e807c72adae))
+* go back to sdi12 sleep after timeout ([fb0ebb8](https://github.com/rrivirr/rriv-firmware/commit/fb0ebb808c1f5ccca49c498c6454ba2c2ea65549))
+* handle garbled out of range data requests without crashing ([7da189c](https://github.com/rrivirr/rriv-firmware/commit/7da189c7c3fc562c802d047cd62e8809f19110d9))
+* handle hung SDI12, timeout and restart command mode ([4a0e857](https://github.com/rrivirr/rriv-firmware/commit/4a0e85718641efe984da3333c3e61f4c62ceb6b6))
+* remove dead code ([4b586cb](https://github.com/rrivirr/rriv-firmware/commit/4b586cbbf9e654bb61059b36e80e1825b2ddd942))
+* remove spamming dfmt message ([740d6a6](https://github.com/rrivirr/rriv-firmware/commit/740d6a697bde83b1b47aacb500a0983115812d52))
+* rename pwm_type to hardware_pwm for clarity ([3829e63](https://github.com/rrivirr/rriv-firmware/commit/3829e63739540852f42dfbef7e73f4f6db0e49a0))
+* rendering order of digits ([8ee73f3](https://github.com/rrivirr/rriv-firmware/commit/8ee73f319daa1a1b05549cb991d8f4745784f208))
+* send a decimal thats only 2 long and format it correctly ([065fc82](https://github.com/rrivirr/rriv-firmware/commit/065fc824444bf6180ae44569b0555425d1b5f281))
+* shorten var names so we dont use up the buffer ([5694fa9](https://github.com/rrivirr/rriv-firmware/commit/5694fa90eab4249a641e569a8ac3f041e5f9df93))
+* uid in usb identity ([289e360](https://github.com/rrivirr/rriv-firmware/commit/289e360869359b30e0aa44dbba4b225dbb7b8750))
+* watch and driver fixes ([33de368](https://github.com/rrivirr/rriv-firmware/commit/33de368f76cddc8f2ce3b3aa52708586645aed63))
+
+
+### Features
+
+* allow selection of output parameters in ring mux driver ([efd491d](https://github.com/rrivirr/rriv-firmware/commit/efd491d4e1368b678bc72312ea7e5f3cc3cb0032))
+* implement mode locking ([28b0308](https://github.com/rrivirr/rriv-firmware/commit/28b03085901103a35a5e314b4c75e05eb896f9e3))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.2](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.1...v1.14.0-preview-sdi12-pwm-groundwater.2) (2026-04-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.9](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.8...v1.14.0-preview-sdi12-pwm-groundwater.9) (2026-04-29)
+
+
+### Bug Fixes
+
+* remove software gpio from hardware pwm ([4220e3e](https://github.com/rrivirr/rriv-firmware/commit/4220e3ee9915ab285e1a522ca9c3e1575ca09879))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.8](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.7...v1.14.0-preview-sdi12-pwm-groundwater.8) (2026-04-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.10](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.9...v1.14.0-preview-sdi12-pwm-groundwater.10) (2026-04-29)
+
+
+### Bug Fixes
+
+* refactor how hardware pwm is applied to resolve sequencing problems ([4146864](https://github.com/rrivirr/rriv-firmware/commit/4146864a5306a4f2709fe42fd6bc6feec41081fd))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.9](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.8...v1.14.0-preview-sdi12-pwm-groundwater.9) (2026-04-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.14](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.13...v1.14.0-preview-sdi12-pwm-groundwater.14) (2026-04-30)
+
+
+### Bug Fixes
+
+* add some improved notification led behavior for boot ([da0dde8](https://github.com/rrivirr/rriv-firmware/commit/da0dde86a92aa4fbc28ab6faf66fbc86b4386390))
+* add some improved notification led behavior for boot ([457e401](https://github.com/rrivirr/rriv-firmware/commit/457e401fad16f14692ffc7146869bf39ccab06fb))
+* correct size of bytes in the special config struct ([e1a90e2](https://github.com/rrivirr/rriv-firmware/commit/e1a90e2b9f01c2ee0b828f6dbba3e2ac14704f86))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.13](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.12...v1.14.0-preview-sdi12-pwm-groundwater.13) (2026-04-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.1](https://github.com/rrivirr/rriv-firmware/compare/v1.13.0...v1.14.0-preview-sdi12-pwm-groundwater.1) (2026-04-17)
+
+
+### Bug Fixes
+
+* added pwm_type in update_from_values fn ([58d7c92](https://github.com/rrivirr/rriv-firmware/commit/58d7c92e0210cd4bcb6489d11ee9db9b78e2d8db))
+* calcuate hardware pwm bool as separate variable ([0dfa725](https://github.com/rrivirr/rriv-firmware/commit/0dfa725624e5b189a4091f5ff6da8314a7974bfe))
+* cargo setup for sdi12 ([d034752](https://github.com/rrivirr/rriv-firmware/commit/d034752e726e9d78360f4a254f3700d97025961d))
+* comment old pwm code ([97ff42d](https://github.com/rrivirr/rriv-firmware/commit/97ff42d2cd00ccfdc3ad00c42a672a3347d93888))
+* Comment out the incomplete uart5 serial for now ([4008de6](https://github.com/rrivirr/rriv-firmware/commit/4008de6713ff69c13c4390de18479b33202923e3))
+* correct order of pin stealing ([2cffc5a](https://github.com/rrivirr/rriv-firmware/commit/2cffc5aca36e276e0e3af2761e27d016c6ed062b))
+* disable pin 1 normal operation ([eee2d00](https://github.com/rrivirr/rriv-firmware/commit/eee2d00e7ba83f859c9400810018d1464e2f8f17))
+* for some reason need to reference boolean to get it to evaluate in if statement ([a9f501f](https://github.com/rrivirr/rriv-firmware/commit/a9f501f63dc1d551e6793fa1cfff59919a998af7))
+* imports ([8f683d6](https://github.com/rrivirr/rriv-firmware/commit/8f683d628aed50f8a35bc861334295e268aa1e96))
+* initial_state code is enabled ([594f8ac](https://github.com/rrivirr/rriv-firmware/commit/594f8ac7b351b57f20f735ce8ad7be4d40444cff))
+* initialize pwm ([caa0d20](https://github.com/rrivirr/rriv-firmware/commit/caa0d20a74f204e219cbf198e315581af012919d))
+* keep clocks object around for later use ([bd5fdd0](https://github.com/rrivirr/rriv-firmware/commit/bd5fdd0bfcc661a83204021f0293046ee5305e35))
+* missing comma ([1a2a92f](https://github.com/rrivirr/rriv-firmware/commit/1a2a92f89e02e187030a2318465646b5ecc021ad))
+* move pwm setup earlier to address hard fault ([af5b1f1](https://github.com/rrivirr/rriv-firmware/commit/af5b1f12627e1862da3e6e16e5de4a57ce1bcbbc))
+* properly unwrap the gpio object ([57b3351](https://github.com/rrivirr/rriv-firmware/commit/57b33513ab0f17e151eec1d3bd3aeac7ed1797ce))
+* remove extra output ([3790569](https://github.com/rrivirr/rriv-firmware/commit/37905690fe983d6a7ad7cf378e2e924426c6c7c5))
+* remove unnecessary gpio6 hard coded setup ([19df4c1](https://github.com/rrivirr/rriv-firmware/commit/19df4c170a1a7621bbdd22277e9cf031ac135049))
+* remove unused column headers code ([2fa0b57](https://github.com/rrivirr/rriv-firmware/commit/2fa0b57d9c5fe7ecda2e02dc53498678ac5cb876))
+* Update ring_w_mux.rs addresses ([fc35a63](https://github.com/rrivirr/rriv-firmware/commit/fc35a63e361e5f0aabf9b35f1f4fcda10435bc1f))
+* Update ring_w_mux.rs final addres fix ([acf0928](https://github.com/rrivirr/rriv-firmware/commit/acf0928e2b838cb59ce9963257a1f4dd035bc781))
+* use PushPull mode ([aa7d70e](https://github.com/rrivirr/rriv-firmware/commit/aa7d70eb5224e51dacb3e7ffecea321ea880fb41))
+* used TIM5 for millis counter ([6756d68](https://github.com/rrivirr/rriv-firmware/commit/6756d68dbca119922fe877f7db01618c258b565b))
+
+
+### Features
+
+* added delay_us fn in rriv board ([027581d](https://github.com/rrivirr/rriv-firmware/commit/027581dd0cbc364b69b47ba24a1b61b9881b801b))
+* added pwm_set_period fn ([28c7b82](https://github.com/rrivirr/rriv-firmware/commit/28c7b82a42054c92b8719be1045808730213778b))
+* applied period fn in timed switch ([8af5cca](https://github.com/rrivirr/rriv-firmware/commit/8af5cca01533848e3f99fa05677ab89485845798))
+* apply pwm in timed_switch ([d8b2187](https://github.com/rrivirr/rriv-firmware/commit/d8b2187eae97e8ecdcc6bac01faeb0baa014f161))
+* define properties and functions for pwm ([0908c72](https://github.com/rrivirr/rriv-firmware/commit/0908c72263994c438dd689500c8b3bc9cea68504))
+* implement the pwm pin ([dfe2501](https://github.com/rrivirr/rriv-firmware/commit/dfe2501f4864bcbf8830d45f23869cc1fa4cb8ee))
+* made sw pwm as additonal configuration ([5c69baa](https://github.com/rrivirr/rriv-firmware/commit/5c69baae60c706cdc91381ea37362daabf508ffe))
+* sdi-12 services ([744d5ac](https://github.com/rrivirr/rriv-firmware/commit/744d5ac7e53867cf2bf5ffa7791526602907905d))
+
 # [1.13.0](https://github.com/rrivirr/rriv-firmware/compare/v1.12.6...v1.13.0) (2026-04-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.2](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.1...v1.14.0-preview-sdi12-pwm-groundwater.2) (2026-04-17)
+
+
+### Bug Fixes
+
+* use the true parameter count ([73174dd](https://github.com/rrivirr/rriv-firmware/commit/73174dd6e91b08823af42e08bcaf8d35336cf8a2))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.1](https://github.com/rrivirr/rriv-firmware/compare/v1.13.0...v1.14.0-preview-sdi12-pwm-groundwater.1) (2026-04-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.7](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.6...v1.14.0-preview-sdi12-pwm-groundwater.7) (2026-04-29)
+
+
+### Bug Fixes
+
+* error out if we end up without any more bits ([754c6ae](https://github.com/rrivirr/rriv-firmware/commit/754c6ae301a8a252fbbf4e41fd35f5e3dbf7daf5))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.6](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.5...v1.14.0-preview-sdi12-pwm-groundwater.6) (2026-04-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.12](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.11...v1.14.0-preview-sdi12-pwm-groundwater.12) (2026-04-30)
+
+
+### Bug Fixes
+
+* add a little delay on timeout ([0659a48](https://github.com/rrivirr/rriv-firmware/commit/0659a4829e7e1c0576b9a0eb449a5837e38e4dde))
+* add some led indications ([2b03ec9](https://github.com/rrivirr/rriv-firmware/commit/2b03ec99e9c991e72438ec8a8f7e7d33f47e673f))
+* dont defmt print the serialrx bytes ([8d7b65c](https://github.com/rrivirr/rriv-firmware/commit/8d7b65cb7cb5198caac34d430c62676ef1665000))
+* dont need empty space in structs anymore ([7532bee](https://github.com/rrivirr/rriv-firmware/commit/7532beed7dce0f408e42078fe24a041865fa4f39))
+* improve debug message ([cc4ed9a](https://github.com/rrivirr/rriv-firmware/commit/cc4ed9a0b7f43b5912b85b1eab3aeec73cc9c12d))
+* improve logic for hardware pwm on/off ([a0e4ca5](https://github.com/rrivirr/rriv-firmware/commit/a0e4ca5e9998a8f0eadeee66d2e3d67da0a64a11))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.11](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.10...v1.14.0-preview-sdi12-pwm-groundwater.11) (2026-04-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.16](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.15...v1.14.0-preview-sdi12-pwm-groundwater.16) (2026-07-22)
+
+
+### Bug Fixes
+
+* improve handling of disable-storage feature ([cf488fc](https://github.com/rrivirr/rriv-firmware/commit/cf488fc21fc95c50b83d72be2045579a5d1bbf4f))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.15](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.14...v1.14.0-preview-sdi12-pwm-groundwater.15) (2026-05-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.6](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.5...v1.14.0-preview-sdi12-pwm-groundwater.6) (2026-04-27)
+
+
+### Bug Fixes
+
+* increase size sdi12 values buffer ([d59e1e3](https://github.com/rrivirr/rriv-firmware/commit/d59e1e3fb2ca36a45dbd8ea04f1a3d285d012931))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.5](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.4...v1.14.0-preview-sdi12-pwm-groundwater.5) (2026-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.4](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.3...v1.14.0-preview-sdi12-pwm-groundwater.4) (2026-04-21)
+
+
+### Bug Fixes
+
+* allow sensor update payloads without sensor type key ([7db5d4f](https://github.com/rrivirr/rriv-firmware/commit/7db5d4f0103615a019ef0a4a9b9fa728c2993e7e))
+* correct id for ring mux ([c160127](https://github.com/rrivirr/rriv-firmware/commit/c16012794f769b7af36d0f9eef6a833796e780d1))
+* increase buffer size for longer rrivctl payloads ([c4ba7b0](https://github.com/rrivirr/rriv-firmware/commit/c4ba7b0eb012b11878435f595249dd69e497f04d))
+* remove that white space ([fd1226b](https://github.com/rrivirr/rriv-firmware/commit/fd1226bf3e84d91fa7b1e1d4ca24cf7eaa4ad8a9))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.3](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.2...v1.14.0-preview-sdi12-pwm-groundwater.3) (2026-04-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.14.0-preview-sdi12-pwm-groundwater.13](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.12...v1.14.0-preview-sdi12-pwm-groundwater.13) (2026-04-30)
+
+
+### Bug Fixes
+
+* hard code hardware pwm mode ([1e26934](https://github.com/rrivirr/rriv-firmware/commit/1e26934ae6e65b2c0a7edb91f67d68cc817c98ea))
+
 # [1.14.0-preview-sdi12-pwm-groundwater.12](https://github.com/rrivirr/rriv-firmware/compare/v1.14.0-preview-sdi12-pwm-groundwater.11...v1.14.0-preview-sdi12-pwm-groundwater.12) (2026-04-30)
 
 

--- a/board/.vscode/launch.json
+++ b/board/.vscode/launch.json
@@ -1,12 +1,12 @@
 {
     "version": "0.2.0",
     "configurations": [
-        // Build and Debug Rust Binary (app)
+        // Build, Flash, and Debug Datalogger Binary
         {
             "type": "probe-rs-debug",
-            "preLaunchTask": "RRIV: Build App Binary Crate",
+            "preLaunchTask": "RRIV: Build Datalogger Debug Binary",
             "request": "launch",
-            "name": "Build, Run, Debug Rust Binary",
+            "name": "Datalogger: Build & Debug",
             "cwd": "${workspaceFolder}",
             "chip": "STM32F103RE",
             "wireProtocol": "Swd",
@@ -37,9 +37,8 @@
                 }
             ],
             "env": {
-                // "RUST_LOG": "trace", // If you set this variable, check the VSCode console log window for the location of the log file.
                 "RUST_BACKTRACE": "1",
-                "RUST_LOG" : "debug"
+                "RUST_LOG" : "debug" // "trace" // If you set this variable, check the VSCode console log window for the location of the log file.
             },
             "linux": {
                 "env": {
@@ -47,20 +46,12 @@
                 }
             },
             "consoleLogLevel": "Console", //Info, Debug
-
-
-            // this is for building with the 24LC08?  not quite working from here
-            // these flags can probably be used with cargo embed?
-            // "cargo": {
-            //     "args": ["build", "--no-default-features", "--features", "24LC08", "-p", "app"]
-            // }
-
         },
-        {
+{
             "type": "probe-rs-debug",
-            "preLaunchTask": "RRIV: Build App Binary Crate",
+            "preLaunchTask": "RRIV: Build Release Binary",
             "request": "attach",
-            "name": "Attach and Debug Rust Binary",
+            "name": "Datalogger: Attach and Debug",
             "cwd": "${workspaceFolder}",
             "chip": "STM32F103RE",
             "wireProtocol": "Swd",
@@ -93,12 +84,12 @@
             },
             "consoleLogLevel": "Console", //Info, Debug
         },
-        // Build Rust Binary in Release Mode (app)
+         // Build Rust Binary in Release Mode (app)
         {
             "type": "probe-rs-debug",
-            "preLaunchTask": "RRIV: Build Release",
+            "preLaunchTask": "RRIV: Build Datalogger Release",
             "request": "launch",
-            "name": "Build & Run Release Rust Binary",
+            "name": "Datalogger Release: Build & Run",
             "cwd": "${workspaceFolder}",
             "chip": "STM32F103RE",
             "wireProtocol": "Swd",
@@ -136,5 +127,111 @@
             },
             "consoleLogLevel": "Console", //Info, Debug
         },
+
+        // Build, Flash, and Debug Probe Binary
+        {
+            "type": "probe-rs-debug",
+            "preLaunchTask": "RRIV: Build Probe Debug Binary",
+            "request": "launch",
+            "name": "Probe: Build & Debug",
+            "cwd": "${workspaceFolder}",
+            "chip": "STM32F103RE",
+            "wireProtocol": "Swd",
+            "runtimeExecutable":"probe-rs",
+            //           "probe": "1366:0101:000801023227", // Modify to match yours if needed, or keep commented
+            "flashingConfig": {
+                "flashingEnabled": true,
+                "haltAfterReset": false,
+                "fullChipErase": true, // faster erasing???
+            },
+            "allowEraseAll" : true, // faster erasing
+            "coreConfigs": [
+                {
+                    "programBinary": "${workspaceFolder}/target/thumbv7m-none-eabi/debug/app",
+                    "svdFile": "${workspaceFolder}/STM32F103xx.svd",
+                    "rttEnabled": true,
+                    "rttChannelFormats": [
+                        {
+                            "channelNumber": 0,
+                            "dataFormat": "String", // Format RTT data as String data
+                            "showTimestamps": true // Include host-side timestamps for every line of data transferred from the target RTT output
+                        },
+                        {
+                            "channelNumber": 1,
+                            "dataFormat": "BinaryLE" // Treat data as raw binary data, and do not format in any way
+                        }
+                    ]
+                }
+            ],
+            "env": {
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG" : "debug" // "trace" // If you set this variable, check the VSCode console log window for the location of the log file.
+            },
+            "linux": {
+                "env": {
+                    "PATH": "${env:HOME}/.cargo/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${env:HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+                }
+            },
+            "consoleLogLevel": "Console", //Info, Debug
+        },
+        {
+            "type": "probe-rs-debug",
+            "preLaunchTask": "RRIV: Build Probe Release",
+            "request": "launch",
+            "name": "Probe Release: Build & Run",
+            "cwd": "${workspaceFolder}",
+            "chip": "STM32F103RE",
+            "wireProtocol": "Swd",
+            "runtimeExecutable":"probe-rs",
+            //           "probe": "1366:0101:000801023227", // Modify to match yours if needed, or keep commented
+            "flashingConfig": {
+                "flashingEnabled": true,
+                "haltAfterReset": false
+            },
+            "coreConfigs": [
+                {
+                    "programBinary": "${workspaceFolder}/target/thumbv7m-none-eabi/release/app",
+                    "svdFile": "${workspaceFolder}/STM32F103xx.svd",
+                    "rttEnabled": true,
+                    "rttChannelFormats": [
+                        {
+                            "channelNumber": 0,
+                            "dataFormat": "String", // Format RTT data as String data
+                            "showTimestamps": true // Include host-side timestamps for every line of data transferred from the target RTT output
+                        },
+                        {
+                            "channelNumber": 1,
+                            "dataFormat": "BinaryLE" // Treat data as raw binary data, and do not format in any way
+                        }
+                    ]
+                }
+            ],
+            "env": {
+                // "RUST_LOG": "trace", // If you set this variable, check the VSCode console log window for the location of the log file.
+            },
+            "linux": {
+                "env": {
+                    "PATH": "${env:HOME}/.cargo/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${env:HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+                }
+            },
+            "consoleLogLevel": "Console", //Info, Debug
+        },
+       
+        {
+            "name": "Clean Debug",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "RRIV: Clean Debug",
+            "runtimeExecutable": "echo",
+            "runtimeArgs": ["Task completed!"]
+        },
+         {
+            "name": "Clean Release",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "RRIV: Clean",
+            "runtimeExecutable": "echo",
+            "runtimeArgs": ["Task completed!"]
+        }
     ],
 }

--- a/board/.vscode/tasks.json
+++ b/board/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "RRIV: Build App Binary Crate",
+            "label": "RRIV: Build Datalogger Debug Binary",
             "type": "shell",
             "command": "cargo",
             "args": [
@@ -18,7 +18,44 @@
             },
         },
         {
-            "label": "RRIV: Build Release App Binary Crate",
+            "label": "RRIV: Build Probe Debug Binary",
+            "type": "shell",
+            "command": "cargo",
+            "args": [
+                "build",
+                "-p=app",
+                "--no-default-features",
+                "--features=storage-disabled"
+            ],
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+        },
+         {
+            "label": "RRIV: Build Probe Release",
+            "type": "shell",
+            "command": "cargo",
+            "args": [
+                "build",
+                "-p=app",
+                "--release",
+                "--no-default-features",
+                "--features=storage-disabled"
+            ],
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+        },
+        {
+            "label": "RRIV: Build Datalogger Release Binary",
             "type": "shell",
             "command": "cargo",
             "args": [
@@ -34,7 +71,7 @@
                 "isDefault": false
             },
         },
-         {
+        {
             "label": "RRIV: Clean",
             "type": "shell",
             "command": "cargo",
@@ -51,10 +88,25 @@
             },
         },
         {
-            "label": "RRIV: Build Release",
+            "label": "RRIV: Clean Debug",
+            "type": "shell",
+            "command": "cargo",
+            "args": [
+                "clean"
+            ],
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+        },
+        {
+            "label": "RRIV: Build Datalogger Release",
             "dependsOn": [
                 "RRIV: Clean",
-                "RRIV: Build Release App Binary Crate"
+                "RRIV: Build Datalogger Release Binary"
             ]
         },
         {

--- a/board/Cargo.lock
+++ b/board/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "one-wire-bus",
  "rriv_board",
  "rtt-target",
+ "sdi12",
  "serde",
  "serde_json",
  "util",
@@ -541,6 +542,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdi12"
+version = "0.1.0"
+dependencies = [
+ "defmt 1.0.1",
+ "format_no_std",
+ "rriv_board",
+ "rtt-target",
+]
 
 [[package]]
 name = "semver"

--- a/board/Cargo.lock
+++ b/board/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
 ]
@@ -472,6 +472,7 @@ name = "rriv_board_0_4_2"
 version = "0.1.0"
 dependencies = [
  "bitfield-struct",
+ "chrono",
  "cortex-m",
  "cortex-m-rt",
  "defmt 1.0.1",

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -10,7 +10,7 @@ description = "RRIV board packages"
 [profile.release]
 opt-level = 'z'     # optimize for size and don't unroll loops
 codegen-units = 1 # setting this to 1 causes better optimizations, but slower code. setting it higher makes compiling parallelizable
-debug = false       # symbols are nice and they don't increase the size on Flash
+debug = false
 lto = true          # link-time optimizations
 strip = true
 
@@ -24,6 +24,7 @@ panic = "abort"
 
 # Optimize all dependencies
 [profile.release.package."*"]
+debug = false
 opt-level = "z"
 
 [profile.dev.package."*"]

--- a/board/app/Cargo.toml
+++ b/board/app/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m-rt = "0.7.3"
 unwrap-infallible = "0.1.5"
 rtt-target = { version = "0.6.1", features =  ["defmt"] }
 embedded-alloc = "0.5.0"
-rriv_board_0_4_2 = { path = "../rriv_board_0_4_2" }
+rriv_board_0_4_2 = { path = "../rriv_board_0_4_2", features=["disable-storage"] }
 datalogger = { path = "../../src/datalogger" }
 rriv_board = { path = "../rriv_board", features = ["24LC08"]}
 defmt = "1.0.1"

--- a/board/app/Cargo.toml
+++ b/board/app/Cargo.toml
@@ -8,22 +8,22 @@ embedded-hal = "0.2.7"
 nb = "1"
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
-
-# Panic behaviour, see https://crates.io/keywords/panic-impl for alternatives
-# panic-halt = "0.2.0"
-# we use a custom panic handler that we implemented ourselves
-
-
-
 unwrap-infallible = "0.1.5"
 rtt-target = { version = "0.6.1", features =  ["defmt"] }
 embedded-alloc = "0.5.0"
-rriv_board_0_4_2 = { path = "../rriv_board_0_4_2", features=["disable-storage"] }
-datalogger = { path = "../../src/datalogger" }
-rriv_board = { path = "../rriv_board", features = ["24LC08"]}
 defmt = "1.0.1"
+
+rriv_board = { path = "../rriv_board"}
+rriv_board_0_4_2 = { path = "../rriv_board_0_4_2"}
+datalogger = { path = "../../src/datalogger" }
 
 [dependencies.stm32f1xx-hal]
 version = "0.10.0"
 features = ["rt", "stm32f103", "high"]
+
+
+[features]
+default = ["storage-sdcard"]
+storage-sdcard = ["rriv_board_0_4_2/storage-sdcard"] 
+storage-disabled = ["rriv_board_0_4_2/storage-disabled"] 
 

--- a/board/rriv_board/Cargo.toml
+++ b/board/rriv_board/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["24LC08"]
 24LC01 = []
 24LC08 = []

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -97,6 +97,7 @@ pub trait RRIVBoard: Send {
 
 
     fn write_gpio_pin(&mut self, pin: u8, value: bool);
+    fn write_pwm_pin_duty(&mut self, value: u8);
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()>;
 
     fn set_gpio_pin_mode(&mut self, pin: u8, mode: GpioMode);

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -98,6 +98,7 @@ pub trait RRIVBoard: Send {
 
     fn write_gpio_pin(&mut self, pin: u8, value: bool);
     fn write_pwm_pin_duty(&mut self, value: u8);
+    fn write_pwm_pin_period(&mut self, period_ms: u32);
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()>;
 
     fn set_gpio_pin_mode(&mut self, pin: u8, mode: GpioMode);

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -66,6 +66,7 @@ pub trait RRIVBoard: Send {
     fn rs485_send(&mut self, message : &[u8]);
     fn serial_debug(&mut self, args: fmt::Arguments);
     fn delay_ms(&mut self, ms: u16);
+    fn delay_us(&mut self, us: u16);
     fn timestamp(&mut self) -> i64;
     fn millis(&mut self) -> u32;
 

--- a/board/rriv_board/src/lib.rs
+++ b/board/rriv_board/src/lib.rs
@@ -20,6 +20,7 @@ pub const EEPROM_TOTAL_SENSOR_SLOTS: usize = 12;
 #[cfg(feature = "24LC01")]
 pub const EEPROM_TOTAL_SENSOR_SLOTS: usize = 2;
 
+
 pub trait RXProcessor: Send + Sync {
     fn process_byte(&mut self, byte: u8);
 }
@@ -119,8 +120,27 @@ pub trait RRIVBoard: Send {
 
     fn get_errors(&self) -> [HardwareError; 5]; // return up to 5 hardware errors currently raised
     fn error_alarm(&mut self); // activate a generic error alarm, normally an LED
-    
+ 
+    // TODO: can't put this here because of 'static, but don't need self anyway
+    // fn configure_gpio_interrupt_function<T: Fn() + 'static>(&self, function: T );
+
+    fn enable_interrupt(&self);
+    fn disable_interrupt(&self);
+    fn get_current_time(&self) -> u32;
+
 }
+
+
+pub static mut GPIO_INTERRUPT_FUNCTION: Option< Box<dyn Fn(u32, bool)> > = None;
+
+pub fn configure_gpio_interrupt_function<T: Fn(u32, bool) + 'static>(function: T ) {
+    // unmask the correct EXTI interrupt for SDI-12 or whatever
+    // store the function we actionally want to call
+    unsafe {
+        GPIO_INTERRUPT_FUNCTION = Some(Box::new(function));
+    }
+}
+
 
 
 pub trait RRIVBoardBuilder {

--- a/board/rriv_board_0_4_2/Cargo.toml
+++ b/board/rriv_board_0_4_2/Cargo.toml
@@ -27,3 +27,9 @@ i2c_hung_fix = "0.1.0"
 bitfield-struct = "0.11.0"
 format_no_std = "1.2.0"
 defmt = "1.0.1"
+
+
+[features]
+default = ["storage"]
+disable-storage = []
+storage = []

--- a/board/rriv_board_0_4_2/Cargo.toml
+++ b/board/rriv_board_0_4_2/Cargo.toml
@@ -30,6 +30,6 @@ defmt = "1.0.1"
 
 
 [features]
-default = ["storage"]
-disable-storage = []
-storage = []
+default = []
+storage-disabled = []
+storage-sdcard = []

--- a/board/rriv_board_0_4_2/Cargo.toml
+++ b/board/rriv_board_0_4_2/Cargo.toml
@@ -27,6 +27,7 @@ i2c_hung_fix = "0.1.0"
 bitfield-struct = "0.11.0"
 format_no_std = "1.2.0"
 defmt = "1.0.1"
+chrono = { version = "0.4.45", default-features = false }
 
 
 [features]

--- a/board/rriv_board_0_4_2/src/components/eeprom.rs
+++ b/board/rriv_board_0_4_2/src/components/eeprom.rs
@@ -57,9 +57,19 @@ pub fn read_bytes_from_eeprom(board: &mut crate::Board, block: u8, start_address
                     defmt::trace!("read {} address {}\n", b[0], message[0]);
                     buffer[i] = b[0];
                 }
-                Err(_) => {
-                    board.usb_serial_send(format_args!("EEPROM read failure, restarting"));
-                    panic!("EEPROM read failure");
+                Err(error) => {
+                    // match error {
+                    //     stm32f1xx_hal::i2c::Error::Bus => todo!(),
+                    //     stm32f1xx_hal::i2c::Error::Arbitration => todo!(),
+                    //     stm32f1xx_hal::i2c::Error::Acknowledge => todo!(),
+                    //     stm32f1xx_hal::i2c::Error::Overrun => todo!(),
+                    //     stm32f1xx_hal::i2c::Error::Timeout => todo!(),
+                    //     _ => todo!(),
+                    // }
+                    let mut err_buf = [0u8; 20];
+                    let err_message = util::format_error(&error, &mut err_buf);
+                    board.usb_serial_send(format_args!("EEPROM read failure, restarting {}", err_message));
+                    panic!("EEPROM read failure {}", err_message);
                 }
             }
             i = i + 1;

--- a/board/rriv_board_0_4_2/src/components/mod.rs
+++ b/board/rriv_board_0_4_2/src/components/mod.rs
@@ -32,6 +32,6 @@ mod one_wire;
 pub use one_wire::*;
 
 pub mod uart5;
-pub use uart5::*;
+// pub use uart5::*;
 
 pub mod gpio;

--- a/board/rriv_board_0_4_2/src/components/precise_delay.rs
+++ b/board/rriv_board_0_4_2/src/components/precise_delay.rs
@@ -18,7 +18,7 @@ impl PreciseDelayUs {
 impl DelayUs<u16> for PreciseDelayUs {
     fn delay_us(&mut self, us: u16) {
         unsafe {
-            let real_cyc = (us * PER_MICROSEC) as u32 / 4;
+            let real_cyc = (us as u32 * PER_MICROSEC as u32) / 4;
             asm!(
                 // Use local labels to avoid R_ARM_THM_JUMP8 relocations which fail on thumbv6m.
                 "1:",

--- a/board/rriv_board_0_4_2/src/components/storage.rs
+++ b/board/rriv_board_0_4_2/src/components/storage.rs
@@ -1,5 +1,6 @@
 use core::panic;
 
+use chrono::DateTime;
 use cortex_m::asm;
 use ds323x::{Datelike, Timelike};
 use embedded_hal::spi::{Mode, Phase, Polarity};
@@ -91,28 +92,27 @@ impl RrivTimeSource {
 // Additinally, in the case of the RRIVBoard, we do not want to query the I2C RTC every time we write
 // therefore, this time should be coming form the internal RTC, which needs to be set to match that I2C RTC
 
-static mut EPOCH_TIMESTAMP: i64 = 0;
+static mut EPOCH_TIMESTAMP: i64 = 0;  // this is only references from a single thread, so static mut is OK
 
 impl TimeSource for RrivTimeSource {
     fn get_timestamp(&self) -> embedded_sdmmc::Timestamp {
 
-      let naive: NaiveDateTime = 
-      unsafe {
-         NaiveDateTime::from_timestamp(EPOCH_TIMESTAMP, 0)	
-      };
-      let time = naive.time();
-      let timestamp = embedded_sdmmc::Timestamp::from_calendar(
-        naive.year().try_into().unwrap(), 
-        naive.month().try_into().unwrap(), 
-        naive.day().try_into().unwrap(), 
+        let datetime = unsafe { DateTime::from_timestamp(EPOCH_TIMESTAMP, 0) };
+        let datetime = datetime.unwrap_or_default();
+
+        let time = datetime.time();
+        let timestamp = embedded_sdmmc::Timestamp::from_calendar(
+        datetime.year().try_into().unwrap(), 
+        datetime.month().try_into().unwrap(), 
+        datetime.day().try_into().unwrap(), 
         time.hour().try_into().unwrap(), 
         time.minute().try_into().unwrap(), 
         time.second().try_into().unwrap()
-      );
-      match timestamp {
-        Ok(timestamp) => timestamp,
-        Err(_err) => Timestamp::from_calendar(0, 0, 0, 0, 0, 0).unwrap()
-      }
+        );
+        match timestamp {
+            Ok(timestamp) => timestamp,
+            Err(_err) => Timestamp::from_calendar(0, 0, 0, 0, 0, 0).unwrap()
+        }
       
     }
 }

--- a/board/rriv_board_0_4_2/src/components/uart5.rs
+++ b/board/rriv_board_0_4_2/src/components/uart5.rs
@@ -126,7 +126,7 @@ unsafe fn UART5() {
             // do a read from the sr register followed by a read from the dr register.
             let _ = usart.sr.read();
             let _ = usart.dr.read();
-            defmt::println!("uart5 error {:?}", defmt::Debug2Format(&err));
+            // defmt::println!("uart5 error {:?}", defmt::Debug2Format(&err));
             // Err(nb::Error::Other(err))
         } else {
             // Check if a byte is available

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -7,8 +7,8 @@ use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
 
 use rriv_board::hardware_error::HardwareError;
-use stm32f1xx_hal::time::MilliSeconds;
-use stm32f1xx_hal::timer::{Ch, CounterUs, PwmHz, Tim4NoRemap};
+use stm32f1xx_hal::time::{MilliSeconds, ms};
+use stm32f1xx_hal::timer::{Ch, Channel, CounterUs, PwmHz, Tim4NoRemap};
 
 use core::fmt::{self};
 use core::mem;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1238,7 +1238,7 @@ impl BoardBuilder {
                 ) {
                     Ok(formatted) => {
                         defmt::println!("{}", formatted); // TODO: this uses format!
-                        // uid_string = formatted;s
+                        uid_string = formatted;
                     }
                     Err(e) => {
                         // doesn't matter

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -62,7 +62,7 @@ use rriv_board::{
     EEPROM_TOTAL_SENSOR_SLOTS, GPIO_INTERRUPT_FUNCTION, RRIVBoard, RXProcessor, SerialRxPeripheral
 };
 
-use ds323x::{DateTimeAccess, Ds323x, NaiveDateTime};
+use ds323x::{DateTimeAccess, Ds323x};
 use stm32f1xx_hal::rtc::Rtc;
 
 use one_wire_bus::{Address, OneWire, SearchState};

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(test), no_std)]
 
+#[cfg(all(feature = "storage-sdcard", feature = "storage-disabled"))]
+compile_error!("feature \"storage-sdcard\" and feature \"storage-disabled\" cannot be enabled at the same time");
+
 extern crate alloc;
 
 use alloc::boxed::Box;
@@ -1463,26 +1466,24 @@ impl BoardBuilder {
 
         let delay2: DelayUs<TIM2> = device_peripherals.TIM2.delay(&clocks);
 
-        let mut enable_storage = true;
-        let storage = None;
-        #[cfg(feature = "disable-storage")]
-        {
-            enable_storage = false;
-        }
-
-        if enable_storage {
+        #[cfg(feature = "storage-sdcard")]
+        let storage: Option<Storage> = {
             watchdog.start(MilliSeconds::secs(24));
             let result = storage::build(spi2_pins, device_peripherals.SPI2, clocks, delay2);
             watchdog.start(MilliSeconds::secs(6));
-            let storage = match result {
+            match result {
                 Ok(storage) => Some(storage),
                 Err(hardware_error) => {
                     add_hardware_error(&mut self.hardware_errors, hardware_error);
                     None
                 },
-            };
+            }
+        };
 
-        }
+        #[cfg(feature = "storage-disabled")]
+        let storage: Option<Storage> = None;
+
+
         if storage.is_none() {
             // sd card library has no way to release the spi and pins
             // so unsafely get the cs pin and flash it

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -5,9 +5,10 @@ extern crate alloc;
 use alloc::boxed::Box;
 use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
-use rriv_board::hardware_error::{HardwareError};
+
+use rriv_board::hardware_error::HardwareError;
 use stm32f1xx_hal::time::MilliSeconds;
-use stm32f1xx_hal::timer::CounterUs;
+use stm32f1xx_hal::timer::{Ch, CounterUs, PwmHz, Tim4NoRemap};
 
 use core::fmt::{self};
 use core::mem;
@@ -126,8 +127,9 @@ pub struct Board {
     one_wire_search_state: Option<SearchState>,
     pub watchdog: IndependentWatchdog,
     pub counter: CounterUs<TIM5>,
-    pub hardware_errors: [HardwareError; 5]
+    pub hardware_errors: [HardwareError; 5],
     pub clocks: Clocks,
+    pub pwm: Option<Box<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>>,
 }
 
 impl Board {
@@ -760,6 +762,10 @@ impl RRIVBoard for Board {
         };
     }
     
+    fn write_pwm_pin_duty(&mut self, value: u8){
+    }
+
+
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()> {
         match pin {
             1 => {
@@ -988,7 +994,7 @@ pub struct BoardBuilder {
     pub storage: Option<Storage>,
     pub watchdog: Option<IndependentWatchdog>,
     pub counter: Option<CounterUs<TIM5>>,
-    hardware_errors: [HardwareError; 5]
+    hardware_errors: [HardwareError; 5],
     pub clocks: Option<Clocks>
 }
 
@@ -1012,7 +1018,7 @@ impl BoardBuilder {
             storage: None,
             watchdog: None,
             counter: None,
-            hardware_errors: [HardwareError::None; 5]
+            hardware_errors: [HardwareError::None; 5],
             clocks: None
         }
     }
@@ -1061,8 +1067,9 @@ impl BoardBuilder {
             one_wire_search_state: None,
             watchdog: watchdog,
             counter: self.counter.unwrap(),
-            hardware_errors: self.hardware_errors
+            hardware_errors: self.hardware_errors,
             clocks: self.clocks.unwrap(),
+            pwm: None,
         }
     }
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use cortex_m::{
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
-use stm32f1xx_hal::gpio::Pin;
+use stm32f1xx_hal::gpio::{Alternate, Pin};
 use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
@@ -129,7 +129,7 @@ pub struct Board {
     pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5],
     pub clocks: Clocks,
-    pub pwm: Option<Box<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>>,
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>,
 }
 
 impl Board {
@@ -149,27 +149,7 @@ impl Board {
         // self.get_sensor_driver_services().write_gpio_pin(2, false);
         // defmt::println!("pin 2 set up"); rriv_board::RRIVBoard::delay_ms(self, 1000);
 
-
-        // hard code a pwm pin
-        let clocks = self.clocks;
-        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
-        let tim4 = device_peripherals.TIM4;
-        let mut afio = device_peripherals.AFIO.constrain();
-        let pin = &mut self.gpio.gpio1;
-        pin.make_open_drain_output(&mut self.gpio_cr.gpiob_crh);  // Dynamic pin not recognized by the HAL pwm construct
-
-
-        // just steal the damn pins.
-        // this pin is not actually moved by the pwm construct, just used as a template generic
-        let gpiob = device_peripherals.GPIOB.split();
-        let pin = gpiob.pb8.into_alternate_open_drain(&mut self.gpio_cr.gpiob_crh);
-    
-        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
-            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
-        pwm.enable(Channel::C3);
-        pwm.set_period(ms(500).into_rate());
-        self.pwm = Some(Box::new(pwm));
-
+        self.delay_ms(2000);
         defmt::println!("board started");
 
     }
@@ -1024,6 +1004,7 @@ pub struct BoardBuilder {
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5],
     pub clocks: Option<Clocks>
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>
 }
 
 impl BoardBuilder {
@@ -1048,6 +1029,7 @@ impl BoardBuilder {
             counter: None,
             hardware_errors: [HardwareError::None; 5],
             clocks: None
+            pwm: None
         }
     }
 
@@ -1097,7 +1079,7 @@ impl BoardBuilder {
             counter: self.counter.unwrap(),
             hardware_errors: self.hardware_errors,
             clocks: self.clocks.unwrap(),
-            pwm: None,
+            pwm: Some(self.pwm.unwrap()),
         }
     }
 
@@ -1367,6 +1349,18 @@ impl BoardBuilder {
         let clocks =
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
 
+
+        let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+        let gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+        let pin = gpiob.pb8.into_alternate_open_drain(&mut gpio_cr.gpiob_crh);
+ 
+
+        let tim4 = device_peripherals.TIM4;
+        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
+            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
+        pwm.enable(Channel::C3);
+        pwm.set_period(ms(500).into_rate());
+        self.pwm = Some(pwm);
 
         // let mut high = true;
         let precise_delay = PreciseDelayUs::new();

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1349,14 +1349,15 @@ impl BoardBuilder {
         // get an unsafe handle on our CS pin so we can flash it
         // and an unsafe hanlde on our PWM pin so we can pass to the config functions
         // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
-        let (mut cs, pwm_pin) = unsafe {
+        let (mut cs, mut sclk_led_enable, pwm_pin) = unsafe {
             let device_peripherals_steal: pac::Peripherals = pac::Peripherals::steal();
             let mut gpioc = device_peripherals_steal.GPIOC.split();
             let cs = gpioc.pc8;
             let cs = cs.into_push_pull_output(&mut gpioc.crh);
             let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
             let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
-            (cs, pwm_pin)
+            let sclk_led_enable = gpiob.pb13.into_push_pull_output_with_state(&mut gpiob.crh, gpio::PinState::Low);
+            (cs, sclk_led_enable, pwm_pin)
         };
 
         // get an unsafe handle on our pwm pin
@@ -1366,7 +1367,6 @@ impl BoardBuilder {
         // let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
 
         
-
 
         // Prepare the GPIO
         let gpioa: gpio::gpioa::Parts = device_peripherals.GPIOA.split();
@@ -1405,12 +1405,14 @@ impl BoardBuilder {
         
         let mut delay: DelayUs<TIM3> = device_peripherals.TIM3.delay(&clocks);
 
-        let mut cs = cs.into_push_pull_output(&mut gpio_cr.gpioc_crh);
-        for i in 0..1 {
+        let mut sclk_led_enable: Pin<'B', 13, Output> = sclk_led_enable.into_floating_input(&mut gpio_cr.gpiob_crh).into_push_pull_output(&mut gpio_cr.gpiob_crh);
+        sclk_led_enable.set_high();
+        let notify_time = 125_u32;
+        for _i in 0..1 {
             cs.set_high();
-            delay.delay_ms(500_u32);
+            delay.delay_ms(notify_time);
             cs.set_low();
-            delay.delay_ms(500_u32);
+            delay.delay_ms(notify_time);
         }
         cs.set_high();
 
@@ -1504,15 +1506,17 @@ impl BoardBuilder {
         self.external_adc.as_mut().unwrap().enable(&mut delay);
         self.external_adc.as_mut().unwrap().reset(&mut delay);
 
+        
         watchdog.feed();
-        cs.set_low();
-        delay.delay_ms(200_u32);
-        cs.set_high();
-        delay.delay_ms(200_u32);
-        cs.set_low();
-        delay.delay_ms(200_u32);
+        for _i in 0..2 {
+            cs.set_high();
+            delay.delay_ms(notify_time);
+            cs.set_low();
+            delay.delay_ms(notify_time);
+        }
         cs.set_high();
         watchdog.feed();
+        
 
         defmt::println!("unhang I2C1 if hung");
 
@@ -1607,11 +1611,11 @@ impl BoardBuilder {
         defmt::println!("scan is done");
 
         watchdog.feed();
-        for i in 0..2 {
+        for _i in 0..3 {
             cs.set_high();
-            delay.delay_ms(500_u32);
+            delay.delay_ms(notify_time);
             cs.set_low();
-            delay.delay_ms(500_u32);
+            delay.delay_ms(notify_time);
         }
         cs.set_high();
         watchdog.feed();
@@ -1689,11 +1693,11 @@ impl BoardBuilder {
         // setup GPIO5 as EXTI2 interrupt PD2
 
         watchdog.feed();
-        for i in 0..3 {
+        for _i in 0..4 {
             cs.set_high();
-            delay.delay_ms(500_u32);
+            delay.delay_ms(notify_time);
             cs.set_low();
-            delay.delay_ms(500_u32);
+            delay.delay_ms(notify_time);
         }
         cs.set_high();
         watchdog.feed();

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1436,7 +1436,6 @@ impl BoardBuilder {
         // let mut high = true;
         let precise_delay = PreciseDelayUs::new();
 
-
         watchdog.feed();
     
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -725,10 +725,10 @@ impl RRIVBoard for Board {
 
     fn write_gpio_pin(&mut self, pin: u8, value: bool) {
         match pin {
-            1 => {
-                let gpio = &mut self.gpio.gpio1;
-                write_gpio!(gpio, value);
-            }
+            // 1 => {
+            //     let gpio = &mut self.gpio.gpio1;
+            //     write_gpio!(gpio, value);
+            // }
             2 => {
                 let gpio = &mut self.gpio.gpio2;
                 write_gpio!(gpio, value);
@@ -776,10 +776,10 @@ impl RRIVBoard for Board {
 
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()> {
         match pin {
-            1 => {
-                let pin =  &mut self.gpio.gpio1;
-                return read_pin!(pin);
-            },
+            // 1 => {
+            //     let pin =  &mut self.gpio.gpio1;
+            //     return read_pin!(pin);
+            // },
             2 => {
                 let pin =  &mut self.gpio.gpio2;
                 return read_pin!(pin);
@@ -817,11 +817,11 @@ impl RRIVBoard for Board {
     fn set_gpio_pin_mode(&mut self, pin: u8, mode: rriv_board::gpio::GpioMode) {
 
         match pin {
-            1 => {
-                let cr = &mut self.gpio_cr.gpiob_crh;
-                let pin: &mut Pin<'B', 8, Dynamic> = &mut self.gpio.gpio1;
-                set_pin_mode!(pin, cr, mode);
-            }
+            // 1 => {
+            //     // let cr = &mut self.gpio_cr.gpiob_crh;
+            //     // let pin: &mut Pin<'B', 8, Dynamic> = &mut self.gpio.gpio1;
+            //     // set_pin_mode!(pin, cr, mode);
+            // }
             2 => {
                 let cr = &mut self.gpio_cr.gpiob_crl;
                 let pin = &mut self.gpio.gpio2;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use cortex_m::{
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
-use stm32f1xx_hal::gpio::{Alternate, Pin};
+use stm32f1xx_hal::gpio::{Alternate, Pin, PushPull};
 use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
@@ -129,7 +129,7 @@ pub struct Board {
     pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5],
     pub clocks: Clocks,
-    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>,
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>>>,
 }
 
 impl Board {
@@ -1004,7 +1004,7 @@ pub struct BoardBuilder {
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5],
     pub clocks: Option<Clocks>,
-    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>
+    pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>>>
 }
 
 impl BoardBuilder {
@@ -1352,11 +1352,11 @@ impl BoardBuilder {
 
         let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
         let gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
-        let pin = gpiob.pb8.into_alternate_open_drain(&mut gpio_cr.gpiob_crh);
+        let pin = gpiob.pb8.into_alternate_push_pull(&mut gpio_cr.gpiob_crh);
  
 
         let tim4 = device_peripherals.TIM4;
-        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
+        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
             tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
         pwm.set_period(ms(500).into_rate());

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -127,6 +127,7 @@ pub struct Board {
     pub watchdog: IndependentWatchdog,
     pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5]
+    pub clocks: Clocks,
 }
 
 impl Board {
@@ -988,6 +989,7 @@ pub struct BoardBuilder {
     pub watchdog: Option<IndependentWatchdog>,
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5]
+    pub clocks: Option<Clocks>
 }
 
 impl BoardBuilder {
@@ -1011,6 +1013,7 @@ impl BoardBuilder {
             watchdog: None,
             counter: None,
             hardware_errors: [HardwareError::None; 5]
+            clocks: None
         }
     }
 
@@ -1059,6 +1062,7 @@ impl BoardBuilder {
             watchdog: watchdog,
             counter: self.counter.unwrap(),
             hardware_errors: self.hardware_errors
+            clocks: self.clocks.unwrap(),
         }
     }
 
@@ -1544,8 +1548,8 @@ impl BoardBuilder {
 
         self.watchdog = Some(watchdog);
 
-        defmt::println!("setting up RS485 serial b");
-        setup_serialb(device_peripherals.UART5, &clocks);
+
+        self.clocks = Some(clocks);
 
         defmt::println!("done with setup");
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1406,10 +1406,12 @@ impl BoardBuilder {
         let mut delay: DelayUs<TIM3> = device_peripherals.TIM3.delay(&clocks);
 
         let mut cs = cs.into_push_pull_output(&mut gpio_cr.gpioc_crh);
-        cs.set_high();
-        delay.delay_ms(500_u32);
-        cs.set_low();
-        delay.delay_ms(500_u32);
+        for i in 0..1 {
+            cs.set_high();
+            delay.delay_ms(500_u32);
+            cs.set_low();
+            delay.delay_ms(500_u32);
+        }
         cs.set_high();
 
         let tim4 = device_peripherals.TIM4;
@@ -1605,16 +1607,12 @@ impl BoardBuilder {
         defmt::println!("scan is done");
 
         watchdog.feed();
-        cs.set_low();
-        delay.delay_ms(200_u32);
-        cs.set_high();
-        delay.delay_ms(200_u32);
-        cs.set_low();
-        delay.delay_ms(200_u32);
-        cs.set_high();
-        delay.delay_ms(200_u32);
-        cs.set_low();
-        delay.delay_ms(200_u32);
+        for i in 0..2 {
+            cs.set_high();
+            delay.delay_ms(500_u32);
+            cs.set_low();
+            delay.delay_ms(500_u32);
+        }
         cs.set_high();
         watchdog.feed();
         
@@ -1671,7 +1669,6 @@ impl BoardBuilder {
 
         self.storage = storage;
 
-        self.delay = Some(delay);
         self.precise_delay = Some(precise_delay);
 
         // the millis counter
@@ -1684,7 +1681,6 @@ impl BoardBuilder {
 
         watchdog.feed();
 
-        self.watchdog = Some(watchdog);
 
         // defmt::println!("setting up RS485 serial b");
         // setup_serialb(device_peripherals.UART5, &clocks);
@@ -1692,7 +1688,19 @@ impl BoardBuilder {
         self.clocks = Some(clocks);
         // setup GPIO5 as EXTI2 interrupt PD2
 
-      
+        watchdog.feed();
+        for i in 0..3 {
+            cs.set_high();
+            delay.delay_ms(500_u32);
+            cs.set_low();
+            delay.delay_ms(500_u32);
+        }
+        cs.set_high();
+        watchdog.feed();
+
+        self.watchdog = Some(watchdog);
+        self.delay = Some(delay);
+
 
         defmt::println!("done with setup");
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1583,6 +1583,8 @@ impl BoardBuilder {
 
         self.watchdog = Some(watchdog);
 
+        // defmt::println!("setting up RS485 serial b");
+        // setup_serialb(device_peripherals.UART5, &clocks);
 
         self.clocks = Some(clocks);
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -938,7 +938,7 @@ unsafe fn USART2() {
         if let Some(ref mut rx) = USART_RX.borrow(cs).borrow_mut().deref_mut() {
             if rx.is_rx_not_empty() {
                 if let Ok(c) = nb::block!(rx.read()) {
-                    defmt::println!("serial rx byte: {}", c);
+                    // defmt::println!("serial rx byte: {}", c);
 
                     let r = USART2_RX_PROCESSOR.borrow(cs);
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -6,6 +6,7 @@ compile_error!("feature \"storage-sdcard\" and feature \"storage-disabled\" cann
 extern crate alloc;
 
 use alloc::boxed::Box;
+use chrono::DateTime;
 use i2c_hung_fix::try_unhang_i2c;
 use one_wire_bus::crc::crc8;
 
@@ -31,8 +32,8 @@ use cortex_m::{
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
-use stm32f1xx_hal::gpio::{Alternate, Edge, ExtiPin, Pin, PushPull};
-use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
+use stm32f1xx_hal::gpio::{Edge, ExtiPin, Pin, PushPull};
+use stm32f1xx_hal::pac::{I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
 use stm32f1xx_hal::{
@@ -394,12 +395,10 @@ impl RRIVBoard for Board {
     fn set_epoch(&mut self, epoch: i64) {
         let i2c1 = mem::replace(&mut self.i2c1, None);
         let mut ds3231 = Ds323x::new_ds3231(i2c1.unwrap());
-        let millis = epoch * 1000;
-        // DateTime::from_timestamp_millis(micros);
-        let datetime = NaiveDateTime::from_timestamp_millis(millis);
+        let datetime = DateTime::from_timestamp(epoch, 0);
         // defmt::println!("{:?}", datetime);
         if let Some(datetime) = datetime {
-            match ds3231.set_datetime(&datetime) {
+            match ds3231.set_datetime(&datetime.naive_utc()) {
                 Ok(_) => {}
                 Err(err) => defmt::println!("Error set epoch {:?}", defmt::Debug2Format(&err)),
             }

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
 use stm32f1xx_hal::gpio::Pin;
-use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, USART2, USB};
+use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
 use stm32f1xx_hal::{
@@ -125,7 +125,7 @@ pub struct Board {
     pub one_wire_bus: Option<OneWire<OneWirePin<Pin<'C', 0, Dynamic>>>>,
     one_wire_search_state: Option<SearchState>,
     pub watchdog: IndependentWatchdog,
-    pub counter: CounterUs<TIM4>,
+    pub counter: CounterUs<TIM5>,
     pub hardware_errors: [HardwareError; 5]
 }
 
@@ -986,7 +986,7 @@ pub struct BoardBuilder {
     pub internal_rtc: Option<Rtc>,
     pub storage: Option<Storage>,
     pub watchdog: Option<IndependentWatchdog>,
-    pub counter: Option<CounterUs<TIM4>>,
+    pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5]
 }
 
@@ -1533,7 +1533,7 @@ impl BoardBuilder {
         self.precise_delay = Some(precise_delay);
 
         // the millis counter
-        let mut counter: CounterUs<TIM4> = device_peripherals.TIM4.counter_us(&clocks);
+        let mut counter: CounterUs<TIM5> = device_peripherals.TIM5.counter_us(&clocks);
         match counter.start(2.micros()) {
             Ok(_) => defmt::println!("Millis counter start ok"),
             Err(err) => defmt::println!("Millis counter start not ok {:?}", defmt::Debug2Format(&err)),

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -28,7 +28,7 @@ use cortex_m::{
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use stm32f1xx_hal::flash::ACR;
-use stm32f1xx_hal::gpio::{Alternate, Pin, PushPull};
+use stm32f1xx_hal::gpio::{Alternate, Edge, ExtiPin, Pin, PushPull};
 use stm32f1xx_hal::pac::{DWT, I2C1, I2C2, TIM2, TIM4, TIM5, USART2, USB};
 use stm32f1xx_hal::serial::StopBits;
 use stm32f1xx_hal::spi::Spi;
@@ -55,7 +55,7 @@ use usb_device::{bus::UsbBusAllocator, prelude::*};
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
 use rriv_board::{
-    EEPROM_TOTAL_SENSOR_SLOTS, RRIVBoard, RXProcessor, SerialRxPeripheral
+    EEPROM_TOTAL_SENSOR_SLOTS, GPIO_INTERRUPT_FUNCTION, RRIVBoard, RXProcessor, SerialRxPeripheral
 };
 
 use ds323x::{DateTimeAccess, Ds323x, NaiveDateTime};
@@ -95,6 +95,7 @@ static USART2_RX_PROCESSOR: Mutex<RefCell<Option<Box<&mut dyn RXProcessor>>>> =
     Mutex::new(RefCell::new(None));
 static UART5_RX_PROCESSOR: Mutex<RefCell<Option<Box<&mut dyn RXProcessor>>>> =
     Mutex::new(RefCell::new(None));
+
 
 #[repr(C)]
 pub struct Usart {
@@ -911,6 +912,20 @@ impl RRIVBoard for Board {
             }
         }
     }
+    
+
+    fn enable_interrupt(&self){
+        unsafe { NVIC::unmask(pac::Interrupt::EXTI2) };
+    }
+    
+    fn disable_interrupt(&self){
+        NVIC::mask(pac::Interrupt::EXTI2);
+    }
+
+    fn get_current_time(&self) -> u32 {
+        cortex_m::peripheral::DWT::cycle_count() / SYSCLK_MHZ
+    }
+
 
 }
 
@@ -952,6 +967,26 @@ fn USB_LP_CAN_RX0() {
         usb_interrupt(cs);
         dmb();
     });
+}
+
+#[interrupt]
+fn EXTI2() {
+    let exti = unsafe { &*pac::EXTI::ptr() };
+    if exti.pr.read().pr2().bit_is_set() {
+        exti.pr.write(|w| w.pr2().set_bit());
+        let now = cortex_m::peripheral::DWT::cycle_count();
+        let is_low = unsafe {(*pac::GPIOD::ptr()).idr.read().bits() & (1 << 2) == 0 };
+        let gpio_state = if is_low { false } else { true };
+        let now = now / SYSCLK_MHZ; // convert to microseconds
+        cortex_m::interrupt::free(|_cs| {
+            unsafe {
+                if let Some(gpio_interrupt_function) = &mut GPIO_INTERRUPT_FUNCTION {
+                    gpio_interrupt_function(now, gpio_state);
+                }
+            }
+        });
+        // defmt::println!("GPIO interrupt at {}", now);
+    }
 }
 
 fn usb_interrupt(cs: &CriticalSection) {
@@ -1177,8 +1212,8 @@ impl BoardBuilder {
             USB_SERIAL = Some(SerialPort::new(USB_BUS.as_ref().unwrap()));
 
             let uid: [u8;12] = Uid::fetch().bytes();
-
-            let arg = format_args!("rriv_{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+            
+            let arg = format_args!("{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",            
                     uid[0],
                     uid[1],
                     uid[2],
@@ -1192,18 +1227,18 @@ impl BoardBuilder {
                     uid[10],
                     uid[11]);
 
-
+            
             #[allow(unused_assignments)]
-            let mut uid_string: &str = "rriv";
-            static mut BUF:[u8;29] = [0u8; 29];
+            let mut uid_string: &str = "_rriv";
+            static mut BUF:[u8;24] = [0u8; 24];
 
             match format_no_std::show(
                     &mut BUF,
-                    arg
+                    arg 
                 ) {
                     Ok(formatted) => {
                         defmt::println!("{}", formatted); // TODO: this uses format!
-                        uid_string = formatted;
+                        // uid_string = formatted;s
                     }
                     Err(e) => {
                         // doesn't matter
@@ -1214,7 +1249,7 @@ impl BoardBuilder {
 
             let usb_dev = UsbDeviceBuilder::new(USB_BUS.as_ref().unwrap(), UsbVidPid(0x0483, 0x29))
                 .manufacturer("RRIV")
-                .product("Data Logger")
+                .product("RRIV Data Logger")
                 .serial_number(uid_string)
                 .device_class(USB_CLASS_CDC)
                 .build();
@@ -1289,7 +1324,7 @@ impl BoardBuilder {
         defmt::println!("board builder setup");
 
         let mut core_peripherals: pac::CorePeripherals = cortex_m::Peripherals::take().unwrap();
-        let device_peripherals: pac::Peripherals = pac::Peripherals::take().unwrap();
+        let mut device_peripherals: pac::Peripherals = pac::Peripherals::take().unwrap();
 
         let mut watchdog = IndependentWatchdog::new(device_peripherals.IWDG);
         watchdog.stop_on_debug(&device_peripherals.DBGMCU, true);
@@ -1385,6 +1420,15 @@ impl BoardBuilder {
         watchdog.feed();
     
 
+        dynamic_gpio_pins.gpio5.make_interrupt_source(&mut afio);
+        dynamic_gpio_pins.gpio5.trigger_on_edge(&mut device_peripherals.EXTI, Edge::RisingFalling);
+        dynamic_gpio_pins.gpio5.enable_interrupt(&mut device_peripherals.EXTI);
+        
+        // unsafe { NVIC::unmask(pac::Interrupt::EXTI2) };
+        // Disable interrupts on start
+        NVIC::mask(pac::Interrupt::EXTI2);
+
+
         BoardBuilder::setup_serial(
             serial_pins,
             &mut afio.mapr,
@@ -1399,16 +1443,27 @@ impl BoardBuilder {
         usb_serial_send("{\"status\":\"usb started up\"}\n", &mut delay);
 
         let delay2: DelayUs<TIM2> = device_peripherals.TIM2.delay(&clocks);
-        watchdog.start(MilliSeconds::secs(24));
-        let storage = storage::build(spi2_pins, device_peripherals.SPI2, clocks, delay2);
-        watchdog.start(MilliSeconds::secs(6));
-        let storage = match storage {
-            Ok(storage) => Some(storage),
-            Err(hardware_error) => {
-                add_hardware_error(&mut self.hardware_errors, hardware_error);
-                None
-            },
-        };
+
+        let mut enable_storage = true;
+        let storage = None;
+        #[cfg(feature = "disable-storage")]
+        {
+            enable_storage = false;
+        }
+
+        if enable_storage {
+            watchdog.start(MilliSeconds::secs(24));
+            let result = storage::build(spi2_pins, device_peripherals.SPI2, clocks, delay2);
+            watchdog.start(MilliSeconds::secs(6));
+            let storage = match result {
+                Ok(storage) => Some(storage),
+                Err(hardware_error) => {
+                    add_hardware_error(&mut self.hardware_errors, hardware_error);
+                    None
+                },
+            };
+
+        }
         if storage.is_none() {
             // sd card library has no way to release the spi and pins
             // so unsafely get the cs pin and flash it
@@ -1460,6 +1515,7 @@ impl BoardBuilder {
         let i2c1_pins = I2c1Pins::rebuild(scl1, sda1, &mut gpio_cr);
 
         // defmt::println!("starting i2c");
+        core_peripherals.DCB.enable_trace();
         core_peripherals.DWT.enable_cycle_counter(); // BlockingI2c says this is required  already
         let mut i2c1 = BoardBuilder::setup_i2c1(
             i2c1_pins,
@@ -1596,10 +1652,14 @@ impl BoardBuilder {
         // setup_serialb(device_peripherals.UART5, &clocks);
 
         self.clocks = Some(clocks);
+        // setup GPIO5 as EXTI2 interrupt PD2
+
+      
 
         defmt::println!("done with setup");
 
     }
+
 }
 
 unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
@@ -1624,7 +1684,7 @@ pub fn usb_serial_send(string: &str, delay: &mut impl DelayMs<u16>) {
                     match err {
                         UsbError::WouldBlock => {
                             if would_block_count > 100 {
-                                defmt::println!("USBWouldBlock limit exceeded");
+                                // defmt::println!("USBWouldBlock limit exceeded");
                                 return;
                             }
                             would_block_count = would_block_count + 1; // handle hung blocking condition.  possibly caused by client not reading and buffer full.

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1402,20 +1402,36 @@ impl BoardBuilder {
 
         let clocks =
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
+        
+        let mut delay: DelayUs<TIM3> = device_peripherals.TIM3.delay(&clocks);
 
+        let mut cs = cs.into_push_pull_output(&mut gpio_cr.gpioc_crh);
+        cs.set_high();
+        delay.delay_ms(500_u32);
+        cs.set_low();
+        delay.delay_ms(500_u32);
+        cs.set_high();
 
         let tim4 = device_peripherals.TIM4;
         let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
             tim4.pwm_hz::<Tim4NoRemap, _, _>(pwm_pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
         pwm.set_period(ms(10).into_rate());
+        
+        // show that pwm is alive
+        pwm.set_duty(Channel::C3, pwm.get_max_duty() / 2);
+        delay.delay_ms(150_u32);
         pwm.set_duty(Channel::C3, 0);
+        delay.delay_ms(150_u32);
+        pwm.set_duty(Channel::C3, pwm.get_max_duty() / 2);
+        delay.delay_ms(150_u32);
+        pwm.set_duty(Channel::C3, 0);
+
         self.pwm = Some(pwm);
 
         // let mut high = true;
         let precise_delay = PreciseDelayUs::new();
 
-        let mut delay: DelayUs<TIM3> = device_peripherals.TIM3.delay(&clocks);
 
         watchdog.feed();
     
@@ -1486,6 +1502,15 @@ impl BoardBuilder {
         self.external_adc.as_mut().unwrap().enable(&mut delay);
         self.external_adc.as_mut().unwrap().reset(&mut delay);
 
+        watchdog.feed();
+        cs.set_low();
+        delay.delay_ms(200_u32);
+        cs.set_high();
+        delay.delay_ms(200_u32);
+        cs.set_low();
+        delay.delay_ms(200_u32);
+        cs.set_high();
+        watchdog.feed();
 
         defmt::println!("unhang I2C1 if hung");
 
@@ -1580,6 +1605,19 @@ impl BoardBuilder {
         defmt::println!("scan is done");
 
         watchdog.feed();
+        cs.set_low();
+        delay.delay_ms(200_u32);
+        cs.set_high();
+        delay.delay_ms(200_u32);
+        cs.set_low();
+        delay.delay_ms(200_u32);
+        cs.set_high();
+        delay.delay_ms(200_u32);
+        cs.set_low();
+        delay.delay_ms(200_u32);
+        cs.set_high();
+        watchdog.feed();
+        
 
         defmt::println!("i2c2 scanning...");
         for addr in 0x00_u8..0x7F {

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1033,10 +1033,6 @@ impl BoardBuilder {
             }
         };
 
-        // TODO: just one GPIO pin for the moment
-        let mut gpio = self.gpio.unwrap();
-        gpio.gpio6.make_push_pull_output(&mut gpio_cr.gpioc_crh);
-
         let mut watchdog = self.watchdog.unwrap();
         watchdog.feed();
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1301,7 +1301,6 @@ impl BoardBuilder {
         let mut pwr = device_peripherals.PWR;
         let mut backup_domain = rcc.bkp.constrain(device_peripherals.BKP, &mut pwr);
 
-
         let uid = Uid::fetch();
         defmt::println!("uid: {:X}", uid.bytes());
         self.uid = Some(uid.bytes());
@@ -1309,7 +1308,6 @@ impl BoardBuilder {
         watchdog.feed();
 
         // get an unsafe handle on our CS pin so we can flash it
-        // and an unsafe hanlde on our PWM pin so we can pass to the config functions
         // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
         let mut cs = unsafe {
             let device_peripherals: pac::Peripherals = pac::Peripherals::steal();
@@ -1317,6 +1315,12 @@ impl BoardBuilder {
             let cs = gpioc.pc8;
             cs.into_push_pull_output(&mut gpioc.crh)
         };
+
+        // get an unsafe handle on our pwm pin
+        // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
+        let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+        let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+        let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
 
 
         // Prepare the GPIO
@@ -1354,15 +1358,11 @@ impl BoardBuilder {
         let clocks =
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
 
-
-        let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
-        let gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
-        let pin = gpiob.pb8.into_alternate_push_pull(&mut gpio_cr.gpiob_crh);
  
 
         let tim4 = device_peripherals.TIM4;
         let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
-            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
+            tim4.pwm_hz::<Tim4NoRemap, _, _>(pwm_pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
         pwm.set_period(ms(10).into_rate());
         pwm.set_duty(Channel::C3, 0u16);

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -773,6 +773,11 @@ impl RRIVBoard for Board {
         }
     }
 
+    fn write_pwm_pin_period(&mut self, period_ms: u32){
+        if let Some(pwm) = &mut self.pwm {
+            pwm.set_period(ms(period_ms).into_rate());
+        }
+    }
 
     fn read_gpio_pin(&mut self, pin: u8) -> Result<bool, ()> {
         match pin {

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1003,7 +1003,7 @@ pub struct BoardBuilder {
     pub watchdog: Option<IndependentWatchdog>,
     pub counter: Option<CounterUs<TIM5>>,
     hardware_errors: [HardwareError; 5],
-    pub clocks: Option<Clocks>
+    pub clocks: Option<Clocks>,
     pub pwm: Option<PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>>>
 }
 
@@ -1028,7 +1028,7 @@ impl BoardBuilder {
             watchdog: None,
             counter: None,
             hardware_errors: [HardwareError::None; 5],
-            clocks: None
+            clocks: None,
             pwm: None
         }
     }

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -148,6 +148,28 @@ impl Board {
         // self.get_sensor_driver_services().set_gpio_pin_mode(2, rriv_board::gpio::GpioMode::PushPullOutput);
         // self.get_sensor_driver_services().write_gpio_pin(2, false);
         // defmt::println!("pin 2 set up"); rriv_board::RRIVBoard::delay_ms(self, 1000);
+
+
+        // hard code a pwm pin
+        let clocks = self.clocks;
+        let device_peripherals: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+        let tim4 = device_peripherals.TIM4;
+        let mut afio = device_peripherals.AFIO.constrain();
+        let pin = &mut self.gpio.gpio1;
+        pin.make_open_drain_output(&mut self.gpio_cr.gpiob_crh);  // Dynamic pin not recognized by the HAL pwm construct
+
+
+        // just steal the damn pins.
+        // this pin is not actually moved by the pwm construct, just used as a template generic
+        let gpiob = device_peripherals.GPIOB.split();
+        let pin = gpiob.pb8.into_alternate_open_drain(&mut self.gpio_cr.gpiob_crh);
+    
+        let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<OpenDrain>>> = 
+            tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
+        pwm.enable(Channel::C3);
+        pwm.set_period(ms(500).into_rate());
+        self.pwm = Some(Box::new(pwm));
+
         defmt::println!("board started");
 
     }
@@ -763,6 +785,12 @@ impl RRIVBoard for Board {
     }
     
     fn write_pwm_pin_duty(&mut self, value: u8){
+        if let Some(pwm) = &mut self.pwm {
+            let max = pwm.get_max_duty();
+            let x1 = max as u32 * (value as u32);
+            let x2 = x1 / 255;
+            pwm.set_duty(Channel::C3, x2 as u16);
+        }
     }
 
 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1308,19 +1308,23 @@ impl BoardBuilder {
         watchdog.feed();
 
         // get an unsafe handle on our CS pin so we can flash it
+        // and an unsafe hanlde on our PWM pin so we can pass to the config functions
         // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
-        let mut cs = unsafe {
-            let device_peripherals: pac::Peripherals = pac::Peripherals::steal();
-            let mut gpioc = device_peripherals.GPIOC.split();
+        let (mut cs, mut pwm_pin) = unsafe {
+            let device_peripherals_steal: pac::Peripherals = pac::Peripherals::steal();
+            let mut gpioc = device_peripherals_steal.GPIOC.split();
             let cs = gpioc.pc8;
-            cs.into_push_pull_output(&mut gpioc.crh)
+            let cs = cs.into_push_pull_output(&mut gpioc.crh);
+            let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+            let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
+            (cs, pwm_pin)
         };
 
         // get an unsafe handle on our pwm pin
         // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
-        let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
-        let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
-        let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
+        // let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
+        // let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+        // let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
 
 
         // Prepare the GPIO
@@ -1359,6 +1363,17 @@ impl BoardBuilder {
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
 
  
+        let (mut cs, mut pwm_pin) = unsafe {
+            let device_peripherals_steal: pac::Peripherals = pac::Peripherals::steal();
+            let mut gpioc = device_peripherals_steal.GPIOC.split();
+            let cs = gpioc.pc8;
+            let cs = cs.into_push_pull_output(&mut gpioc.crh);
+            let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
+            let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
+            (cs, pwm_pin)
+        };
+
+
 
         let tim4 = device_peripherals.TIM4;
         let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1487,11 +1487,11 @@ impl BoardBuilder {
         if storage.is_none() {
             // sd card library has no way to release the spi and pins
             // so unsafely get the cs pin and flash it
-            for _i in 1..10 {
+            for _i in 1..20 {
                 cs.set_high();
-                delay.delay_ms(100_u32);
+                delay.delay_ms(50_u32);
                 cs.set_low();
-                delay.delay_ms(100_u32);
+                delay.delay_ms(50_u32);
             }
             cs.set_high();
             

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1310,7 +1310,7 @@ impl BoardBuilder {
         // get an unsafe handle on our CS pin so we can flash it
         // and an unsafe hanlde on our PWM pin so we can pass to the config functions
         // this steal has to happen before we set up the GPIO pins otherwise things get reset wrongly
-        let (mut cs, mut pwm_pin) = unsafe {
+        let (mut cs, pwm_pin) = unsafe {
             let device_peripherals_steal: pac::Peripherals = pac::Peripherals::steal();
             let mut gpioc = device_peripherals_steal.GPIOC.split();
             let cs = gpioc.pc8;
@@ -1325,6 +1325,8 @@ impl BoardBuilder {
         // let device_peripherals_steal: pac::Peripherals = unsafe { pac::Peripherals::steal() };
         // let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
         // let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
+
+        
 
 
         // Prepare the GPIO
@@ -1362,25 +1364,13 @@ impl BoardBuilder {
         let clocks =
             BoardBuilder::setup_clocks(&mut oscillator_control_pins, rcc.cfgr, &mut flash.acr);
 
- 
-        let (mut cs, mut pwm_pin) = unsafe {
-            let device_peripherals_steal: pac::Peripherals = pac::Peripherals::steal();
-            let mut gpioc = device_peripherals_steal.GPIOC.split();
-            let cs = gpioc.pc8;
-            let cs = cs.into_push_pull_output(&mut gpioc.crh);
-            let mut gpiob = device_peripherals_steal.GPIOB.split(); // this line is the problem????  yeah
-            let pwm_pin = gpiob.pb8.into_alternate_push_pull(&mut gpiob.crh);
-            (cs, pwm_pin)
-        };
-
-
 
         let tim4 = device_peripherals.TIM4;
         let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
             tim4.pwm_hz::<Tim4NoRemap, _, _>(pwm_pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
         pwm.set_period(ms(10).into_rate());
-        pwm.set_duty(Channel::C3, 0u16);
+        pwm.set_duty(Channel::C3, 0);
         self.pwm = Some(pwm);
 
         // let mut high = true;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1359,7 +1359,8 @@ impl BoardBuilder {
         let mut pwm: PwmHz<TIM4, Tim4NoRemap, Ch<2>, Pin<'B', 8, gpio::Alternate<PushPull>>> = 
             tim4.pwm_hz::<Tim4NoRemap, _, _>(pin, &mut afio.mapr, 1.kHz(), &clocks);
         pwm.enable(Channel::C3);
-        pwm.set_period(ms(500).into_rate());
+        pwm.set_period(ms(10).into_rate());
+        pwm.set_duty(Channel::C3, 0u16);
         self.pwm = Some(pwm);
 
         // let mut high = true;

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -1045,7 +1045,7 @@ impl BoardBuilder {
             i2c2: self.i2c2.unwrap(),
             delay: self.delay.unwrap(),
             precise_delay: self.precise_delay.unwrap(),
-            gpio: gpio,
+            gpio: self.gpio.unwrap(),
             gpio_cr: gpio_cr,
             // // power_control: self.power_control.unwrap(),
             internal_adc: internal_adc,

--- a/board/rriv_board_0_4_2/src/lib.rs
+++ b/board/rriv_board_0_4_2/src/lib.rs
@@ -383,6 +383,10 @@ impl RRIVBoard for Board {
         self.delay.delay_ms(ms);
     }
 
+    fn delay_us(&mut self, us: u16) {
+        self.precise_delay.delay_us(us);
+    }
+
     fn set_epoch(&mut self, epoch: i64) {
         let i2c1 = mem::replace(&mut self.i2c1, None);
         let mut ds3231 = Ds323x::new_ds3231(i2c1.unwrap());

--- a/board/rriv_board_0_4_2/src/pin_groups/dynamic_gpio.rs
+++ b/board/rriv_board_0_4_2/src/pin_groups/dynamic_gpio.rs
@@ -2,7 +2,7 @@ use stm32f1xx_hal::gpio::*;
 use crate::pins::*;
 
 pub struct DynamicGpioPins {
-    pub gpio1: Pin<'B', 8, Dynamic>,
+    pub gpio1: Pin<'B', 8, Alternate<OpenDrain>>,
     pub gpio2: Pin<'B', 5, Dynamic>,
     pub gpio3: Pin<'B', 4, Dynamic>,
     pub gpio4: Pin<'B', 3, Dynamic>,
@@ -25,7 +25,7 @@ impl DynamicGpioPins {
         cr: &mut GpioCr,
     ) -> Self {
         return DynamicGpioPins {
-            gpio1: gpio1.into_dynamic(&mut cr.gpiob_crh),
+            gpio1: gpio1.into_alternate_open_drain(&mut cr.gpiob_crh),
             gpio2: gpio2.into_dynamic(&mut cr.gpiob_crl),
             gpio3: gpio3.into_dynamic(&mut cr.gpiob_crl),
             gpio4: gpio4.into_dynamic(&mut cr.gpiob_crl),

--- a/board/rriv_board_0_4_2/src/pin_groups/dynamic_gpio.rs
+++ b/board/rriv_board_0_4_2/src/pin_groups/dynamic_gpio.rs
@@ -2,7 +2,7 @@ use stm32f1xx_hal::gpio::*;
 use crate::pins::*;
 
 pub struct DynamicGpioPins {
-    pub gpio1: Pin<'B', 8, Alternate<OpenDrain>>,
+    pub gpio1: Pin<'B', 8, Alternate<PushPull>>,
     pub gpio2: Pin<'B', 5, Dynamic>,
     pub gpio3: Pin<'B', 4, Dynamic>,
     pub gpio4: Pin<'B', 3, Dynamic>,
@@ -25,7 +25,7 @@ impl DynamicGpioPins {
         cr: &mut GpioCr,
     ) -> Self {
         return DynamicGpioPins {
-            gpio1: gpio1.into_alternate_open_drain(&mut cr.gpiob_crh),
+            gpio1: gpio1.into_alternate_push_pull(&mut cr.gpiob_crh),
             gpio2: gpio2.into_dynamic(&mut cr.gpiob_crl),
             gpio3: gpio3.into_dynamic(&mut cr.gpiob_crl),
             gpio4: gpio4.into_dynamic(&mut cr.gpiob_crl),

--- a/src/control_interface/src/command_recognizer.rs
+++ b/src/control_interface/src/command_recognizer.rs
@@ -4,8 +4,12 @@
 
 
 
-pub const BUFFER_NUM: usize = 3; // Includes an extra empty cell for end marker, TODO: what a waste!
-pub const BUFFER_SIZE: usize = 320;
+pub const BUFFER_NUM: usize = 2; // Includes an extra empty cell for end marker, TODO: what a waste!
+pub const BUFFER_SIZE: usize = 500;
+
+// TODO
+// wasting space like in the above doesn't make sense.  This needs to work as one block of memory, either receive a single command 
+// or if receiving multiple commands save them in order.  that's the only answer.
 
 pub struct CommandData {
     receiving: bool,

--- a/src/control_interface/src/command_recognizer.rs
+++ b/src/control_interface/src/command_recognizer.rs
@@ -5,7 +5,7 @@
 
 
 pub const BUFFER_NUM: usize = 3; // Includes an extra empty cell for end marker, TODO: what a waste!
-pub const BUFFER_SIZE: usize = 200;
+pub const BUFFER_SIZE: usize = 320;
 
 pub struct CommandData {
     receiving: bool,

--- a/src/datalogger/Cargo.toml
+++ b/src/datalogger/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rriv_board = { path = "../../board/rriv_board" } 
 control_interface = { path = "../../src/control_interface" }
 util = { path = "../../src/util"}
+sdi12 = { path = "../../src/sdi12"}
 hashbrown = { version="0.14", default-features=false }
 serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/src/datalogger/Cargo.toml
+++ b/src/datalogger/Cargo.toml
@@ -22,3 +22,7 @@ format_no_std = "1.2.0"
 defmt = "1.0.1"
 num-traits = { version = "0.2", default-features = false }
 
+
+[features]
+default = []
+sdi-12-locked = []

--- a/src/datalogger/src/datalogger/modes.rs
+++ b/src/datalogger/src/datalogger/modes.rs
@@ -4,7 +4,8 @@
 pub enum DataLoggerMode {
     Interactive = 1,
     Field = 2,
-    HibernateUntil = 3
+    HibernateUntil = 3,
+    SDI12 = 4,
 }
 
 impl DataLoggerMode {
@@ -16,6 +17,7 @@ impl DataLoggerMode {
     match index {
         2 => DataLoggerMode::Field,
         3 => DataLoggerMode::HibernateUntil,
+        4 => DataLoggerMode::SDI12,
         _ => DataLoggerMode::Interactive
     }
   }
@@ -26,6 +28,7 @@ pub fn mode_text(mode: &DataLoggerMode) -> &'static str {
         DataLoggerMode::Interactive => "interactive",
         DataLoggerMode::Field => "field",
         DataLoggerMode::HibernateUntil => "hibernate",
+        DataLoggerMode::SDI12 => "sdi12",
     }
 }
 

--- a/src/datalogger/src/datalogger/payloads.rs
+++ b/src/datalogger/src/datalogger/payloads.rs
@@ -21,6 +21,7 @@ pub struct DataloggerSettingsValues {
     pub enable_lorawan_telemetry: Option<bool>,
     pub enable_modbus_rtu: Option<bool>,
     pub interactive_logging: Option<bool>,
+    pub enable_sdi12: Option<bool>
 }
 
 #[derive(Serialize, Deserialize)]
@@ -38,6 +39,7 @@ pub struct DataloggerSetPayload {
     pub enable_lorawan_telemetry: Option<bool>,
     pub enable_modbus_rtu: Option<bool>,
     pub interactive_logging: Option<bool>,
+    pub enable_sdi12: Option<bool>,
     // pub user_note: Option<Value>, // not implemented for now
     // pub user_value: Option<i16>
 }
@@ -114,6 +116,9 @@ impl DataloggerSetPayload {
             datalogger_settings_values.enable_modbus_rtu = Some(enable_modbus_rtu);
         }
 
+        if let Some(enable_sdi12) = self.enable_sdi12 {
+            datalogger_settings_values.enable_sdi12 = Some(enable_sdi12);
+        }
 
         datalogger_settings_values
     }

--- a/src/datalogger/src/datalogger/payloads.rs
+++ b/src/datalogger/src/datalogger/payloads.rs
@@ -21,7 +21,8 @@ pub struct DataloggerSettingsValues {
     pub enable_lorawan_telemetry: Option<bool>,
     pub enable_modbus_rtu: Option<bool>,
     pub interactive_logging: Option<bool>,
-    pub enable_sdi12: Option<bool>
+    pub enable_sdi12: Option<bool>,
+    pub lock_mode: Option<bool>
 }
 
 #[derive(Serialize, Deserialize)]
@@ -40,6 +41,7 @@ pub struct DataloggerSetPayload {
     pub enable_modbus_rtu: Option<bool>,
     pub interactive_logging: Option<bool>,
     pub enable_sdi12: Option<bool>,
+    pub lock_mode: Option<bool>
     // pub user_note: Option<Value>, // not implemented for now
     // pub user_value: Option<i16>
 }
@@ -118,6 +120,10 @@ impl DataloggerSetPayload {
 
         if let Some(enable_sdi12) = self.enable_sdi12 {
             datalogger_settings_values.enable_sdi12 = Some(enable_sdi12);
+        }
+
+        if let Some(lock_mode) = self.lock_mode {
+            datalogger_settings_values.lock_mode = Some(lock_mode);
         }
 
         datalogger_settings_values

--- a/src/datalogger/src/datalogger/payloads.rs
+++ b/src/datalogger/src/datalogger/payloads.rs
@@ -185,13 +185,15 @@ impl SensorSetPayload {
                         Ok(sensor_type) => sensor_type_id = Some(sensor_type),
                         Err(_) => {
                             // responses::send_command_response_message(board, "sensor type not found");
-                            return Err("sensor type not found");
+                            // return Err("sensor type not found");
+                            sensor_type_id = None;
                         }
                     }
                 }
                 _ => {
                     // responses::send_command_response_message(board, "sensor type not specified");
-                    return Err("sensor type not specified");
+                    // return Err("sensor type not specified");
+                    sensor_type_id = None;
                 }
             }
         } else {

--- a/src/datalogger/src/datalogger/settings.rs
+++ b/src/datalogger/src/datalogger/settings.rs
@@ -9,29 +9,29 @@ const DATALOGGER_SETTINGS_UNUSED_BYTES: usize = 13;
 #[bitfield(u8)]
 #[derive(PartialEq)]
 pub struct DataloggerSettingsBitField {
-    #[bits(1)]
+    #[bits(1, default = true)]
     pub external_adc_enabled: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_lorawan_telemetry: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_modbus_rtu: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub debug_includes_values: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub withhold_incomplete_readings: bool,
 
-    #[bits(1)]
+    #[bits(1, default = true)]
     pub log_raw_data: bool,
 
-    #[bits(1)]
+    #[bits(1, default = false)]
     pub enable_interactive_logging: bool,
 
-    #[bits(1)]
-    unused: usize,
+    #[bits(1, default = false)]
+    pub enable_sdi12: bool,
 }
 
 
@@ -142,6 +142,7 @@ impl DataloggerSettings {
         settings.toggles.set_enable_lorawan_telemetry(values.enable_lorawan_telemetry.unwrap_or(self.toggles.enable_lorawan_telemetry()));
         settings.toggles.set_enable_modbus_rtu(values.enable_modbus_rtu.unwrap_or(self.toggles.enable_modbus_rtu()));
         settings.toggles.set_enable_interactive_logging(values.interactive_logging.unwrap_or(self.toggles.enable_interactive_logging()));
+        settings.toggles.set_enable_sdi12(values.enable_sdi12.unwrap_or(self.toggles.enable_sdi12()));
         settings
     }
 

--- a/src/datalogger/src/datalogger/settings.rs
+++ b/src/datalogger/src/datalogger/settings.rs
@@ -19,7 +19,7 @@ pub struct DataloggerSettingsBitField {
     pub enable_modbus_rtu: bool,
 
     #[bits(1, default = false)]
-    pub debug_includes_values: bool,
+    pub lock_mode: bool,
 
     #[bits(1, default = false)]
     pub withhold_incomplete_readings: bool,
@@ -143,6 +143,7 @@ impl DataloggerSettings {
         settings.toggles.set_enable_modbus_rtu(values.enable_modbus_rtu.unwrap_or(self.toggles.enable_modbus_rtu()));
         settings.toggles.set_enable_interactive_logging(values.interactive_logging.unwrap_or(self.toggles.enable_interactive_logging()));
         settings.toggles.set_enable_sdi12(values.enable_sdi12.unwrap_or(self.toggles.enable_sdi12()));
+        settings.toggles.set_lock_mode(values.lock_mode.unwrap_or(self.toggles.lock_mode()));
         settings
     }
 

--- a/src/datalogger/src/drivers/adc_temperature.rs
+++ b/src/datalogger/src/drivers/adc_temperature.rs
@@ -87,8 +87,9 @@ impl SensorDriver for ADCTemperatureDriver {
         Ok(())
     }
    
-    #[allow(unused)]
-    fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+     #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
     }
         
 }

--- a/src/datalogger/src/drivers/aht20.rs
+++ b/src/datalogger/src/drivers/aht20.rs
@@ -221,7 +221,12 @@ impl SensorDriver for AHT20 {
     }
     
     fn clear_calibration(&mut self) {
-        defmt::println!("not implemented");
+        defmt::println!("clear calibration not implemented");
+    }
+
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
     }
 
 }

--- a/src/datalogger/src/drivers/atlas_ec.rs
+++ b/src/datalogger/src/drivers/atlas_ec.rs
@@ -127,6 +127,11 @@ impl SensorDriver for AtlasEC {
             self.measured_parameter_values[0] = f64::MAX;
         }
     }
+
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
 }
 
 

--- a/src/datalogger/src/drivers/ds18b20.rs
+++ b/src/datalogger/src/drivers/ds18b20.rs
@@ -287,6 +287,11 @@ impl SensorDriver for Ds18b20 {
     }
 
     fn clear_calibration(&mut self) {
-        // defmt::println!("not implemented");
+        defmt::println!("clear calibration not implemented");
+    }
+
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
     }
 }

--- a/src/datalogger/src/drivers/generic_analog.rs
+++ b/src/datalogger/src/drivers/generic_analog.rs
@@ -112,6 +112,11 @@ impl SensorDriver for GenericAnalog {
         Ok(())
     }
 
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
+
 }
 
 impl GenericAnalog {

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -1,0 +1,59 @@
+use crate::drivers::types::SensorDriver;
+
+
+struct MyDigitalPin {
+    pub func new(&mut board);
+    pub func release() -> &mut board;
+}
+
+impl digital_pin for MyDigitalPin {
+    // the write and read functions
+}
+
+struct GroundwaterFlowSDI12 {
+
+}
+
+
+impl SensorDriver for GroundwaterFlowSDI12 {
+    fn get_configuration_bytes(&self, storage: &mut [u8; rriv_board::EEPROM_SENSOR_SETTINGS_SIZE]) {
+        todo!()
+    }
+
+    fn get_configuration_json(&mut self) -> serde_json::Value {
+        todo!()
+    }
+
+    fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        todo!()
+    }
+
+    fn get_id(&self) -> [u8; 6] {
+        todo!()
+    }
+
+    fn get_type_id(&self) -> u16 {
+        todo!()
+    }
+
+    fn get_measured_parameter_count(&mut self) -> usize {
+        todo!()
+    }
+
+    fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
+        todo!()
+    }
+
+    fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
+        todo!()
+    }
+
+    fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        let command = "aM"; // not done
+
+        let my_digital_pin = MyDigitalPin::new(&mut board);
+
+
+        sdi12::send_command(&commmand, my_digital_pin, my_delay_us);
+    }
+}

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -1,59 +1,341 @@
-use crate::drivers::types::SensorDriver;
-
-
-struct MyDigitalPin {
-    pub func new(&mut board);
-    pub func release() -> &mut board;
+use crate::{drivers::types::SensorDriver, services::sdi12_service};
+use crate::sensor_name_from_type_id;
+use serde_json::json;
+use super::types::*;
+    
+#[derive(Copy, Clone)]
+pub struct GroundwaterFlowSDI12SpecialConfiguration {
+    gpio: u8,
+    sensor_address: char,
+    measured_parameter_count: usize
 }
 
-impl digital_pin for MyDigitalPin {
-    // the write and read functions
+impl GroundwaterFlowSDI12SpecialConfiguration {
+    pub fn parse_from_values(value: serde_json::Value) -> Result<GroundwaterFlowSDI12SpecialConfiguration, &'static str> {
+        
+        let gpio_pin = match &value["gpio_pin"] {
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_u64() {
+                    if number >= 1 && number <= 8 {
+                        Some(number as u8)
+                    } else {
+                        return Err("invalid pin");
+                    }           
+                } else {
+                    return Err("invalid pin");
+                }
+            }
+            _ => {
+                return Err("gpio pin is required")
+            }
+        };
+
+        let address = match &value["sensor_address"] {
+            serde_json::Value::String(s) => s.chars().next().unwrap_or('\0'),
+            _ => return Err("sensor_address must be a single character from '0' to '9'"),
+        };
+
+        let measured_parameter_count = match &value["measured_parameter_count"] {
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_u64() {
+                    if number <= 9 {
+                        number as usize
+                    } else {
+                        return Err("measured_parameter_count must be between 0 and 9");
+                    }
+                } else {
+                    return Err("invalid measured_parameter_count");
+                }
+            }
+            _ => return Err("measured_parameter_count is required"),
+        };
+
+        Ok ( Self {
+            gpio: gpio_pin.unwrap(),
+            sensor_address: address,
+            measured_parameter_count: measured_parameter_count
+        } ) 
+    }
+
+    pub fn new_from_bytes(
+        bytes: [u8; SENSOR_SETTINGS_PARTITION_SIZE],
+    ) -> GroundwaterFlowSDI12SpecialConfiguration {
+        let settings = bytes
+            .as_ptr()
+            .cast::<GroundwaterFlowSDI12SpecialConfiguration>();
+        unsafe { *settings }
+    }
 }
 
-struct GroundwaterFlowSDI12 {
-
+pub struct GroundwaterFlowSDI12 {
+    general_config: SensorDriverGeneralConfiguration,
+    special_config: GroundwaterFlowSDI12SpecialConfiguration,
+    data_received: [f32; 36],
+    num_data: usize,
+    index: usize,
+    start: usize,
+    mode: u8, // 0 for command mode, 1 for data mode
 }
 
 
 impl SensorDriver for GroundwaterFlowSDI12 {
-    fn get_configuration_bytes(&self, storage: &mut [u8; rriv_board::EEPROM_SENSOR_SETTINGS_SIZE]) {
-        todo!()
-    }
+
+    getters!();
 
     fn get_configuration_json(&mut self) -> serde_json::Value {
-        todo!()
+        let mut sensor_id = self.get_id();
+        let sensor_id = match util::str_from_utf8(&mut sensor_id) {
+            Ok(sensor_id) => sensor_id,
+            Err(_) => "Invalid",
+        };
+
+        let mut sensor_name = sensor_name_from_type_id(self.get_type_id().into());
+        let sensor_name = match util::str_from_utf8(&mut sensor_name) {
+            Ok(sensor_name) => sensor_name,
+            Err(_) => "Invalid",
+        };
+
+        json!({
+           "id" : sensor_id,
+           "type" : sensor_name,
+           "gpio_pin": self.special_config.gpio,
+           "sensor_address": self.special_config.sensor_address,
+           "measured_parameter_count": self.special_config.measured_parameter_count
+        })
     }
 
+    #[allow(unused)]
     fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        todo!()
-    }
-
-    fn get_id(&self) -> [u8; 6] {
-        todo!()
-    }
-
-    fn get_type_id(&self) -> u16 {
-        todo!()
+        board.set_gpio_pin_mode(5, rriv_board::gpio::GpioMode::PullDownInput);
+        let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
+        sdi12_service.setup();
     }
 
     fn get_measured_parameter_count(&mut self) -> usize {
-        todo!()
+        self.num_data as usize
     }
 
     fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
-        todo!()
+        Ok(self.data_received[index] as f64)
     }
 
     fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
-        todo!()
+        let mut buffer = [0u8; 16];
+        buffer[0..6].copy_from_slice("value_".as_bytes());
+        let c = char::from_digit(index as u32, 10).unwrap();
+        let a = c as u8;
+        buffer[6] = a;
+        buffer
     }
 
     fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        let command = "aM"; // not done
 
-        let my_digital_pin = MyDigitalPin::new(&mut board);
+        // let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
+        // loop {
+        //     sdi12_service.send_break(board);
+        //     match sdi12_service.send_m_command(board, '0') {
+        //         Some(m_response) => {
+        //             self.num_data = m_response.n as usize;
+        //             defmt::println!("Response received:\nttt: {}\tn: {}", m_response.ttt, m_response.n);
+        //             if m_response.ttt > 0 {
+        //                 // process the delay
+        //                 let mut now = board.epoch_timestamp();
+        //                 let trigger = now + m_response.ttt as i64;
+        //                 while now < trigger {
+        //                     board.usb_serial_send(format_args!("SDI12: waiting...\n"));
+        //                     board.run_loop_iteration(); // feeds the watchdog and keeps the board layer updated
+        //                     board.delay_ms(1000);
+        //                     now = board.epoch_timestamp();
+        //                 }
+        //                 break;
+        //             }
+        //         }
+        //         None => {
+        //             self.num_data = 0;
+        //             defmt::println!("Invalid ack to M command. Retrying...");
+        //             board.delay_ms(1000);
+        //             board.run_loop_iteration();
+        //         }
+        //     }
+        // }
+        // let mut total_measurements: usize = 0;
+        // loop {
+        //     sdi12_service.send_break(board);
+        //     match sdi12_service.send_ha_command(board) {
+        //         Some(ha_response) => {
+        //             self.num_data = ha_response.nnn as usize;
+        //             total_measurements = ha_response.nnn as usize;
+        //             defmt::println!("Response received:\nttt: {}\tn: {}", ha_response.ttt, ha_response.nnn);
+        //             if ha_response.ttt > 0 {
+        //                 // process the delay
+        //                 let mut now = board.epoch_timestamp();
+        //                 let trigger = now + ha_response.ttt as i64;
+        //                 while now < trigger {
+        //                     board.usb_serial_send(format_args!("SDI12: waiting...\n"));
+        //                     board.run_loop_iteration(); // feeds the watchdog and keeps the board layer updated
+        //                     board.delay_ms(1000);
+        //                     now = board.epoch_timestamp();
+        //                 }
+        //                 break;
+        //             }
+        //         }
+        //         None => {
+        //             self.num_data = 0;
+        //             defmt::println!("Invalid ack to M command. Retrying...");
+        //             board.delay_ms(1000);
+        //             board.run_loop_iteration();
+        //         }
+        //     }
+        // }
 
+        // let mut index: usize = 0;
+        // let mut start = 0;
+        // sdi12_service.send_break(board);    // Break for D0 only
+        // loop {
+        //     match sdi12_service.send_d_command(board, index as u8) {
+        //         Some(d_response) => {
+        //             let end = start + d_response.count as usize;
+        //             for i in start..end {
+        //                 self.data_received[i] = d_response.data[i-start];
+        //             }
 
-        sdi12::send_command(&commmand, my_digital_pin, my_delay_us);
+        //             if end == total_measurements as usize {
+        //                 defmt::println!("Received all data!");
+        //                 break;
+        //             }
+        //             start = end;
+        //             if index == 999 {
+        //                 defmt::println!("Sent D999 and still didn't receive all the data");
+        //                 break;
+        //             }
+        //             else {
+        //                 index += 1;
+        //                 board.delay_ms(1000);
+        //                 board.run_loop_iteration();
+        //             }
+        //         },
+        //         None => {
+        //             board.delay_ms(1000);
+        //             board.run_loop_iteration();
+        //             sdi12_service.send_break(board);
+        //         }
+        //     }
+        // }
+
+        // Interrupt Implementation
+        if self.mode == 0 {
+            self.command_mode(board);
+        }
+        else {
+            self.data_mode(board);
+        }
+
     }
+}
+
+impl GroundwaterFlowSDI12 {
+    pub fn new(
+        general_config: SensorDriverGeneralConfiguration,
+        special_config: GroundwaterFlowSDI12SpecialConfiguration,
+    ) -> Self {
+        GroundwaterFlowSDI12 {
+            general_config,
+            special_config,
+            data_received: [0.0; 36],
+            num_data: 0,
+            index: 0,
+            start: 0,
+            mode: 0,
+        }
+    }
+
+    pub fn command_mode(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
+        sdi12_service.send_break(board);
+        sdi12_service.send_command(board, sdi12_service::Sdi12Command::HA);
+
+        // if received, process the buffer
+        let buffer = sdi12_service.read_response(board);
+        if buffer.is_err() {
+            self.num_data = 0;
+            defmt::println!("Timeout to HA command. Retrying...");
+            self.mode = 0; // stay in command mode
+            return;
+        }
+        let ha_response = sdi12_service.parse_ha_command(buffer.unwrap());
+        match ha_response {
+            Some(ha_response) => {
+                self.num_data = ha_response.nnn as usize;
+                defmt::println!("Response received:\nttt: {}\tn: {}", ha_response.ttt, ha_response.nnn);
+                if ha_response.ttt > 0 {
+                    // process the delay
+                    let mut now = board.epoch_timestamp();
+                    let trigger = now + ha_response.ttt as i64;
+                    while now < trigger {
+                        board.usb_serial_send(format_args!("SDI12: waiting...\n"));
+                        board.run_loop_iteration(); // feeds the watchdog and keeps the board layer updated
+                        board.delay_ms(1000);
+                        now = board.epoch_timestamp();
+                    }
+                }
+                self.mode = 1; // switch to data mode
+            },
+            None => {
+                self.num_data = 0;
+                defmt::println!("Invalid ack to M command.");
+                self.mode = 0; // stay in command mode
+                return;
+            }
+        }
+    }
+
+    pub fn data_mode(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
+        // if self.index == 0 {
+            sdi12_service.send_break(board);    // Break for D0 only
+        // }
+        let ind_char = (b'0' + (self.index as u8)) as char;
+        sdi12_service.send_command(board, sdi12_service::Sdi12Command::D(ind_char));
+
+        // if received, process the buffer
+        let buffer = sdi12_service.read_response(board);
+        if buffer.is_err() {
+            defmt::println!("Timeout to D{} command. Retrying...", self.index);
+            self.mode = 1; // stay in data mode to try again
+            return;
+        }
+        let d_response = sdi12_service.parse_d_command(board, buffer.unwrap());
+        match d_response {
+            Some(d_response) => {
+                let end = self.start + d_response.count as usize;
+                for i in self.start..end {
+                    self.data_received[i] = d_response.data[i-self.start];
+                    defmt::println!("Received data[{}]: {}", i, self.data_received[i]);
+                }
+
+                if end >= self.num_data as usize {
+                    defmt::println!("Received all data!");
+                    self.mode = 0; // switch back to command mode for next measurement
+                    self.index = 0;
+                    self.start = 0;
+                }
+                else if self.index == 999 {
+                    defmt::println!("Sent D999 and still didn't receive all the data");
+                    self.mode = 0; // switch back to command mode to try again next time
+                    self.index = 0;
+                    self.start = 0;
+                }
+                else {
+                    self.start = end;
+                    self.index += 1;
+                }
+            },
+            None => {
+                defmt::println!("Invalid ack to D{} command.", self.index);
+                self.mode = 1; // stay in data mode to try again
+            }
+        }
+        board.delay_ms(1000);
+    }
+
 }

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -260,6 +260,11 @@ impl SensorDriver for GroundwaterFlowSDI12 {
             }
         }
     }
+    
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
 }
 
 impl GroundwaterFlowSDI12 {

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -235,19 +235,27 @@ impl SensorDriver for GroundwaterFlowSDI12 {
         // }
 
         // Interrupt Implementation
+        let max  = 20;
         if self.mode == 0 {
-            loop {
+            for i in 0..max {
                 let ack = self.command_mode(board);
                 if ack {
                     break;
                 }
+                if i == max - 1 {
+                    defmt::println!("SDI12: command timed out");
+                }
             }
         }
         if self.mode == 1 {
-            loop {
+            for i in 0..max {
                 let done = self.data_mode(board);
                 if done {
                     break;
+                }
+                if i == max - 1 {
+                    self.mode = 0;
+                    defmt::println!("SDI12: data timed out");
                 }
             }
         }
@@ -301,6 +309,7 @@ impl GroundwaterFlowSDI12 {
                     }
                 }
                 self.mode = 1; // switch to data mode
+                self.index = 0;
                 ack_received = true;
             },
             None => {

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -129,10 +129,10 @@ impl SensorDriver for GroundwaterFlowSDI12 {
         } else {
             let c = char::from_digit((index as u32) % 10, 10).unwrap();
             let a = c as u8;
-            buffer[6] = a;
+            buffer[7] = a;
             let c = char::from_digit((index as u32) / 10, 10).unwrap();
             let a = c as u8;
-            buffer[7] = a;
+            buffer[6] = a;
         }
         buffer
     }

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -139,6 +139,9 @@ impl SensorDriver for GroundwaterFlowSDI12 {
 
     fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
 
+        // clear the data
+        self.data_received =  [0.0; 36];
+
         // let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
         // loop {
         //     sdi12_service.send_break(board);

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -334,6 +334,7 @@ impl GroundwaterFlowSDI12 {
         let buffer = sdi12_service.read_response(board);
         if buffer.is_err() {
             defmt::println!("Timeout to D{} command. Retrying...", self.index);
+            board.delay_ms(100); // wait briefly.
             self.mode = 1; // stay in data mode to try again
             return false;
         }

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -122,9 +122,18 @@ impl SensorDriver for GroundwaterFlowSDI12 {
     fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
         let mut buffer = [0u8; 16];
         buffer[0..6].copy_from_slice("value_".as_bytes());
-        let c = char::from_digit(index as u32, 10).unwrap();
-        let a = c as u8;
-        buffer[6] = a;
+        if index < 10 {
+            let c = char::from_digit(index as u32, 10).unwrap();
+            let a = c as u8;
+            buffer[6] = a;
+        } else {
+            let c = char::from_digit((index as u32) % 10, 10).unwrap();
+            let a = c as u8;
+            buffer[6] = a;
+            let c = char::from_digit((index as u32) / 10, 10).unwrap();
+            let a = c as u8;
+            buffer[7] = a;
+        }
         buffer
     }
 
@@ -224,12 +233,21 @@ impl SensorDriver for GroundwaterFlowSDI12 {
 
         // Interrupt Implementation
         if self.mode == 0 {
-            self.command_mode(board);
+            loop {
+                let ack = self.command_mode(board);
+                if ack {
+                    break;
+                }
+            }
         }
-        else {
-            self.data_mode(board);
+        if self.mode == 1 {
+            loop {
+                let done = self.data_mode(board);
+                if done {
+                    break;
+                }
+            }
         }
-
     }
 }
 
@@ -249,18 +267,19 @@ impl GroundwaterFlowSDI12 {
         }
     }
 
-    pub fn command_mode(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+    pub fn command_mode(&mut self, board: &mut dyn rriv_board::RRIVBoard) -> bool {
         let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
         sdi12_service.send_break(board);
         sdi12_service.send_command(board, sdi12_service::Sdi12Command::HA);
 
+        let mut ack_received = false;
         // if received, process the buffer
         let buffer = sdi12_service.read_response(board);
         if buffer.is_err() {
             self.num_data = 0;
             defmt::println!("Timeout to HA command. Retrying...");
             self.mode = 0; // stay in command mode
-            return;
+            return ack_received;
         }
         let ha_response = sdi12_service.parse_ha_command(buffer.unwrap());
         match ha_response {
@@ -279,17 +298,19 @@ impl GroundwaterFlowSDI12 {
                     }
                 }
                 self.mode = 1; // switch to data mode
+                ack_received = true;
             },
             None => {
                 self.num_data = 0;
                 defmt::println!("Invalid ack to M command.");
                 self.mode = 0; // stay in command mode
-                return;
+                ack_received = false;
             }
         }
+        ack_received
     }
 
-    pub fn data_mode(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+    pub fn data_mode(&mut self, board: &mut dyn rriv_board::RRIVBoard) -> bool {
         let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
         // if self.index == 0 {
             sdi12_service.send_break(board);    // Break for D0 only
@@ -302,8 +323,9 @@ impl GroundwaterFlowSDI12 {
         if buffer.is_err() {
             defmt::println!("Timeout to D{} command. Retrying...", self.index);
             self.mode = 1; // stay in data mode to try again
-            return;
+            return false;
         }
+        let mut received_all_data = false;
         let d_response = sdi12_service.parse_d_command(board, buffer.unwrap());
         match d_response {
             Some(d_response) => {
@@ -318,6 +340,7 @@ impl GroundwaterFlowSDI12 {
                     self.mode = 0; // switch back to command mode for next measurement
                     self.index = 0;
                     self.start = 0;
+                    received_all_data = true;
                 }
                 else if self.index == 999 {
                     defmt::println!("Sent D999 and still didn't receive all the data");
@@ -335,7 +358,9 @@ impl GroundwaterFlowSDI12 {
                 self.mode = 1; // stay in data mode to try again
             }
         }
-        board.delay_ms(1000);
+        board.delay_ms(50);
+        board.run_loop_iteration();
+        received_all_data
     }
 
 }

--- a/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
+++ b/src/datalogger/src/drivers/groundwater_flow_sdi12.rs
@@ -70,7 +70,7 @@ impl GroundwaterFlowSDI12SpecialConfiguration {
 pub struct GroundwaterFlowSDI12 {
     general_config: SensorDriverGeneralConfiguration,
     special_config: GroundwaterFlowSDI12SpecialConfiguration,
-    data_received: [f32; 36],
+    data_received: [f32; 100],
     num_data: usize,
     index: usize,
     start: usize,
@@ -140,7 +140,7 @@ impl SensorDriver for GroundwaterFlowSDI12 {
     fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
 
         // clear the data
-        self.data_received =  [0.0; 36];
+        self.data_received =  [0.0; 100];
 
         // let mut sdi12_service = sdi12_service::Sdi12TxProcessor::new(self.special_config.gpio, self.special_config.sensor_address);
         // loop {
@@ -270,7 +270,7 @@ impl GroundwaterFlowSDI12 {
         GroundwaterFlowSDI12 {
             general_config,
             special_config,
-            data_received: [0.0; 36],
+            data_received: [0.0; 100],
             num_data: 0,
             index: 0,
             start: 0,

--- a/src/datalogger/src/drivers/k30_co2.rs
+++ b/src/datalogger/src/drivers/k30_co2.rs
@@ -167,6 +167,11 @@ impl SensorDriver for K30CO2 {
         Ok(())
     }
 
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
+
 }
 
 impl K30CO2 {

--- a/src/datalogger/src/drivers/mcp9808.rs
+++ b/src/datalogger/src/drivers/mcp9808.rs
@@ -189,6 +189,11 @@ impl SensorDriver for MCP9808TemperatureDriver {
        defmt::println!("fit {}", self.special_config.calibration_offset);    
        Ok(())
     }
+
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
         
 }
 

--- a/src/datalogger/src/drivers/mhz9041a.rs
+++ b/src/datalogger/src/drivers/mhz9041a.rs
@@ -305,6 +305,11 @@ impl SensorDriver for MHZ9041ADriver {
         self.special_config.calibration_offset = (self.calibration_offset * 1000_f64) as i16;
         Ok(())
     }
+    
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
 }
 
 // ─── Constructor ────────────────────────────────────────────────────────────────

--- a/src/datalogger/src/drivers/mod.rs
+++ b/src/datalogger/src/drivers/mod.rs
@@ -16,5 +16,6 @@ pub mod aht20;
 pub mod adc_temperature;
 pub mod resources;
 pub mod modbus;
+pub mod groundwater_flow_sdi12;
 pub mod mhz9041a;
 

--- a/src/datalogger/src/drivers/mod.rs
+++ b/src/datalogger/src/drivers/mod.rs
@@ -8,6 +8,7 @@ pub mod generic_analog;
 pub mod ring_temperature;
 pub mod ring_w_mux;
 pub mod ring_temperature_sim;
+pub mod ring_w_mux_sim;
 pub mod timed_switch_2;
 pub mod ds18b20;
 pub mod k30_co2;

--- a/src/datalogger/src/drivers/modbus.rs
+++ b/src/datalogger/src/drivers/modbus.rs
@@ -139,6 +139,10 @@ impl SensorDriver for ModbusDriver {
 
         
     }
+    
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        todo!()
+    }
 }
 
 // impl Rs485DataRequestDriver {

--- a/src/datalogger/src/drivers/ring_temperature.rs
+++ b/src/datalogger/src/drivers/ring_temperature.rs
@@ -114,13 +114,18 @@ impl SensorDriver for RingTemperatureDriver {
 
     // TODO: this should come from a derived trait
     fn get_configuration_json(&mut self) -> serde_json::Value {
-        // let sensor_id_str: [u8; 6] = core::str::from_utf8(self.get_id());
+
+        let mut sensor_id = self.get_id();
+        let sensor_id = match util::str_from_utf8(&mut sensor_id) {
+            Ok(sensor_id) => sensor_id,
+            Err(_) => "Invalid",
+        };
 
         let sensor_name_bytes = sensor_name_from_type_id(self.get_type_id().into());
         let sensor_name_str = core::str::from_utf8(&sensor_name_bytes).unwrap_or_default();
 
         json!({
-            "id" : self.get_id(),
+            "id" : sensor_id,
             "type" : sensor_name_str,
             "calibration_offset": self.special_config.calibration_offset
         })

--- a/src/datalogger/src/drivers/ring_temperature.rs
+++ b/src/datalogger/src/drivers/ring_temperature.rs
@@ -224,4 +224,8 @@ impl SensorDriver for RingTemperatureDriver {
         Ok(())
     }
 
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
 }

--- a/src/datalogger/src/drivers/ring_temperature_sim.rs
+++ b/src/datalogger/src/drivers/ring_temperature_sim.rs
@@ -4,7 +4,6 @@ use crate::sensor_name_from_type_id;
 
 use super::types::*;
 use alloc::boxed::Box;
-use rtt_target::rprint;
 use serde_json::json;
 
 // TODO: calibration offsets for all 6 sensors need to be stored and loaded into this driver, and written to EEPROM.

--- a/src/datalogger/src/drivers/ring_temperature_sim.rs
+++ b/src/datalogger/src/drivers/ring_temperature_sim.rs
@@ -222,4 +222,9 @@ impl SensorDriver for RingTemperatureDriver {
         }
         Ok(())
     }
+
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
+    }
 }

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -317,7 +317,12 @@ impl SensorDriver for RingMuxTemperatureDriver {
 
     // TODO: this should come from a derived trait
     fn get_configuration_json(&mut self) -> serde_json::Value {
-        // let sensor_id_str: [u8; 6] = core::str::from_utf8(self.get_id());
+        
+        let mut sensor_id = self.get_id();
+        let sensor_id = match util::str_from_utf8(&mut sensor_id) {
+            Ok(sensor_id) => sensor_id,
+            Err(_) => "Invalid",
+        };
 
         let mut sensor_name = sensor_name_from_type_id(self.get_type_id().into());
         let sensor_name = match util::str_from_utf8(&mut sensor_name) {
@@ -325,7 +330,7 @@ impl SensorDriver for RingMuxTemperatureDriver {
             Err(_) => "Invalid",
         };
         json!({
-            "id" : self.get_id(),
+            "id" : sensor_id,
             "type" : sensor_name,
             "calibration_offset": self.special_config.calibration_offset,
             "channels": self.special_config.channels,

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -489,7 +489,9 @@ impl SensorDriver for RingMuxTemperatureDriver {
         }
         Ok(())
     }
-
-    fn update_actuators(&mut self, _board: &mut dyn rriv_board::RRIVBoard) {
+    
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
     }
 }

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -7,7 +7,6 @@ use super::mcp9808::*;
 use super::types::*;
 use alloc::boxed::Box;
 use bitfield_struct::bitfield;
-use rtt_target::rprint;
 use serde_json::json;
 
 const MULTIPLEXER_ADDRESS: u8 = 0x70;

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -182,7 +182,7 @@ impl RingMuxTemperatureDriver {
         let mut addresses = [0u8; TEMPERATURE_SENSORS_ON_RING];
         if special_config.sensors == 6 {
             addresses = [
-                0b0011110, 0b0011101, 0b0011000, 0b0011100, 0b0011110, 0b0011010, 0, 0
+                0b0011110, 0b0011101, 0b0011000, 0b0011100, 0b0011001, 0b0011010, 0, 0
             ];
         }
         else if special_config.sensors == 8 {

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -317,7 +317,7 @@ impl SensorDriver for RingMuxTemperatureDriver {
 
     // TODO: this should come from a derived trait
     fn get_configuration_json(&mut self) -> serde_json::Value {
-        
+
         let mut sensor_id = self.get_id();
         let sensor_id = match util::str_from_utf8(&mut sensor_id) {
             Ok(sensor_id) => sensor_id,

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -114,14 +114,14 @@ impl RingMuxTemperatureDriverSpecialConfiguration {
         }
 
         let mut measurement_outputs = MeasurementOutputs::new();
-        match &value["measurements_raw"] {
+        match &value["m_raw"] {
             serde_json::Value::Bool(value) => {
                 measurement_outputs.set_raw(*value);
             }
             _ => {}
         }
 
-        match &value["measurements_calibrated"] {
+        match &value["m_cal"] {
             serde_json::Value::Bool(value) => {
                 measurement_outputs.set_calibrated(*value);
             }
@@ -330,10 +330,10 @@ impl SensorDriver for RingMuxTemperatureDriver {
             "calibration_offset": self.special_config.calibration_offset,
             "channels": self.special_config.channels,
             "sensors": self.special_config.sensors,
-            "measurements_raw" : self.special_config.measurement_outputs.raw(),
-            "measurements_calibrated" : self.special_config.measurement_outputs.calibrated(),
-            "measurements_differences" : self.special_config.measurement_outputs.differences(),
-            "measurements_vector" : self.special_config.measurement_outputs.vector(),
+            "m_raw" : self.special_config.measurement_outputs.raw(),
+            "m_cal" : self.special_config.measurement_outputs.calibrated(),
+            // "measurements_differences" : self.special_config.measurement_outputs.differences(),
+            // "measurements_vector" : self.special_config.measurement_outputs.vector(),
         })
     }
 

--- a/src/datalogger/src/drivers/ring_w_mux.rs
+++ b/src/datalogger/src/drivers/ring_w_mux.rs
@@ -182,7 +182,7 @@ impl RingMuxTemperatureDriver {
         let mut addresses = [0u8; TEMPERATURE_SENSORS_ON_RING];
         if special_config.sensors == 6 {
             addresses = [
-                0b0011110, 0b0011010, 0b0011000, 0b0011100, 0b0011110, 0b0011101, 0, 0
+                0b0011110, 0b0011101, 0b0011000, 0b0011100, 0b0011110, 0b0011010, 0, 0
             ];
         }
         else if special_config.sensors == 8 {

--- a/src/datalogger/src/drivers/ring_w_mux_sim.rs
+++ b/src/datalogger/src/drivers/ring_w_mux_sim.rs
@@ -4,7 +4,6 @@ use crate::sensor_name_from_type_id;
 
 use super::types::*;
 use alloc::boxed::Box;
-use rtt_target::rprint;
 use serde_json::json;
 
 const MULTIPLEXER_ADDRESS: u8 = 0x70;
@@ -179,8 +178,8 @@ impl RingMuxTemperatureDriver {
         
         let message: [u8; 1] = [1 << channel];
         match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
-            Ok(_) => rprint!("Enabled multiplexer channel {}\n", channel),
-            Err(_) => rprint!("Failed to enable multiplexer channel {}\n", channel),
+            Ok(_) => defmt::println!("Enabled multiplexer channel {}\n", channel),
+            Err(_) => defmt::println!("Failed to enable multiplexer channel {}\n", channel),
         }
     }
 
@@ -190,7 +189,7 @@ impl RingMuxTemperatureDriver {
         let message: [u8; 1] = [0xFF];
         match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
             Ok(_) => (),
-            Err(_) => rprint!("Failed to enable all multiplexer channels\n"),
+            Err(_) => defmt::println!("Failed to enable all multiplexer channels\n"),
         }
     }
 
@@ -201,15 +200,15 @@ impl RingMuxTemperatureDriver {
         
         match board.ic2_read(MULTIPLEXER_ADDRESS, &mut message) {
             Ok(_) => {
-                rprint!("Multiplexer state before disabling channel {}: {:08b}\n", channel, message[0]);
+                defmt::println!("Multiplexer state before disabling channel {}: {:08b}\n", channel, message[0]);
             },
-            Err(_) => rprint!("Failed to read multiplexer state to disable channel {}\n", channel),
+            Err(_) => defmt::println!("Failed to read multiplexer state to disable channel {}\n", channel),
         }
 
         message[0] &= !(1 << channel);
         match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
             Ok(_) => (),
-            Err(_) => rprint!("Failed to disable multiplexer channel {}\n", channel),
+            Err(_) => defmt::println!("Failed to disable multiplexer channel {}\n", channel),
         }
     }
 
@@ -218,9 +217,9 @@ impl RingMuxTemperatureDriver {
         let message: [u8; 1] = [0];
         match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
             Ok(_) => {
-                rprint!("Disabled all multiplexer channels\n");
+                defmt::println!("Disabled all multiplexer channels\n");
             },
-            Err(_) => rprint!("Failed to disable multiplexer channels\n"),
+            Err(_) => defmt::println!("Failed to disable multiplexer channels\n"),
         }
     }
 
@@ -354,7 +353,7 @@ impl SensorDriver for RingMuxTemperatureDriver {
 
         if pairs[0].values.len() < 6 {
             // TODO: check for zeros, not for len().  len is constant
-            rprint!("not enough values to calibrate");
+            defmt::println!("not enough values to calibrate");
             return Err(());
         }
 

--- a/src/datalogger/src/drivers/ring_w_mux_sim.rs
+++ b/src/datalogger/src/drivers/ring_w_mux_sim.rs
@@ -376,6 +376,8 @@ impl SensorDriver for RingMuxTemperatureDriver {
         Ok(())
     }
 
-    fn update_actuators(&mut self, _board: &mut dyn rriv_board::RRIVBoard) {
+    #[allow(unused_variables)]
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str> {
+        Err("update not implemented")
     }
 }

--- a/src/datalogger/src/drivers/ring_w_mux_sim.rs
+++ b/src/datalogger/src/drivers/ring_w_mux_sim.rs
@@ -1,0 +1,382 @@
+// use alloc::fmt::format;
+
+use crate::sensor_name_from_type_id;
+
+use super::types::*;
+use alloc::boxed::Box;
+use rtt_target::rprint;
+use serde_json::json;
+
+const MULTIPLEXER_ADDRESS: u8 = 0x70;
+// TODO: calibration offsets for all 6 sensors need to be stored and loaded into this driver, and written to EEPROM.
+
+#[derive(Copy, Clone)]
+pub struct RingMuxTemperatureDriverSpecialConfiguration {
+    channels: usize,
+    sensors: usize,
+    calibration_offset: [i16; 8], // 16
+    address_offset: u8, // 1
+}
+
+impl RingMuxTemperatureDriverSpecialConfiguration {
+    pub fn parse_from_values(value: serde_json::Value) -> Result<RingMuxTemperatureDriverSpecialConfiguration, &'static str> {
+        
+        let mut channels = 0;
+        match &value["channels"] {
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_u64() {
+                    let number: Result<usize, _> = number.try_into();
+                    match number {
+                        Ok(number) => {
+                            channels = number;
+                        }
+                        Err(_) => return Err("invalid channels")
+                    }
+                }
+            }
+            _ => {
+                channels = 0;
+            }
+        }
+
+        if channels > 8 {
+            return Err("channels must be between 0 and 8");
+        }
+
+        let mut sensors = 6;
+        match &value["sensors"] {
+            serde_json::Value::Number(number) => {
+                if let Some(number) = number.as_u64() {
+                    let number: Result<usize, _> = number.try_into();
+                    match number {
+                        Ok(number) => {
+                            sensors = number;
+                        }
+                        Err(_) => return Err("invalid number of sensors")
+                    }
+                }
+            }
+            _ => {
+                sensors = 6; // default to 6
+            }
+        }
+
+        Ok ( Self {
+            channels: channels,
+            sensors: sensors,
+            calibration_offset: [0; TEMPERATURE_SENSORS_ON_RING],
+            address_offset: 0,
+        } ) // Just using default address offset of 0 for now, need to optionally read from JSON
+    }
+
+    pub fn new_from_bytes(
+        bytes: [u8; SENSOR_SETTINGS_PARTITION_SIZE],
+    ) -> RingMuxTemperatureDriverSpecialConfiguration {
+        let settings = bytes
+            .as_ptr()
+            .cast::<RingMuxTemperatureDriverSpecialConfiguration>();
+        unsafe { *settings }
+    }
+}
+
+const TEMPERATURE_SENSORS_ON_RING: usize = 8;
+const MAX_CHANNELS: usize = 8;
+
+pub struct RingMuxTemperatureDriver {
+    general_config: SensorDriverGeneralConfiguration,
+    special_config: RingMuxTemperatureDriverSpecialConfiguration,
+    measured_parameter_values: [f64; TEMPERATURE_SENSORS_ON_RING * 2 * MAX_CHANNELS], // 8 channels
+    // sensor_drivers: [MCP9808TemperatureDriver; TEMPERATURE_SENSORS_ON_RING],
+}
+
+impl RingMuxTemperatureDriver {
+    pub fn new(
+        general_config: SensorDriverGeneralConfiguration,
+        special_config: RingMuxTemperatureDriverSpecialConfiguration,
+    ) -> Self {
+
+        let mut addresses = [0u8; TEMPERATURE_SENSORS_ON_RING];
+        if special_config.sensors == 6 {
+            addresses = [
+                0b0011110, 0b0011010, 0b0011000, 0b0011100, 0b0011110, 0b0011101, 0, 0
+            ];
+        }
+        else if special_config.sensors == 8 {
+            addresses = [
+                0b0011001, 0b0011000, 0b0011100, 0b0011101, 0b0011010, 0b0011111, 0b0011011, 0b0011110
+            ];
+        }
+        for i in 0..TEMPERATURE_SENSORS_ON_RING {
+            addresses[i] = addresses[i] + special_config.address_offset;
+        }
+
+        RingMuxTemperatureDriver {
+            general_config,
+            special_config,
+            measured_parameter_values: [0.0; TEMPERATURE_SENSORS_ON_RING * 2 * 8],
+            // sensor_drivers: [
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[0],
+            //         ),
+            //         addresses[0],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[1],
+            //         ),
+            //         addresses[1],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[2],
+            //         ),
+            //         addresses[2],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[3],
+            //         ),
+            //         addresses[3],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[4],
+            //         ),
+            //         addresses[4],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[5],
+            //         ),
+            //         addresses[5],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[6],
+            //         ),
+            //         addresses[6],
+            //     ),
+            //     MCP9808TemperatureDriver::new_with_address(
+            //         SensorDriverGeneralConfiguration::empty(),
+            //         MCP9808TemperatureDriverSpecialConfiguration::new(
+            //             special_config.calibration_offset[7],
+            //         ),
+            //         addresses[7],
+            //     ),
+            // ],
+        }
+    }
+
+    fn enable_channel(&self, channel: usize, board: &mut dyn rriv_board::RRIVBoard) {
+        
+        let message: [u8; 1] = [1 << channel];
+        match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
+            Ok(_) => rprint!("Enabled multiplexer channel {}\n", channel),
+            Err(_) => rprint!("Failed to enable multiplexer channel {}\n", channel),
+        }
+    }
+
+    #[allow(unused)]
+    fn enable_all_channels(&self, board: &mut dyn rriv_board::RRIVBoard) {
+        
+        let message: [u8; 1] = [0xFF];
+        match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
+            Ok(_) => (),
+            Err(_) => rprint!("Failed to enable all multiplexer channels\n"),
+        }
+    }
+
+    #[allow(unused)]
+    fn disable_channel(&self, channel: usize, board: &mut dyn rriv_board::RRIVBoard) {
+        
+        let mut message: [u8; 1] = [0];
+        
+        match board.ic2_read(MULTIPLEXER_ADDRESS, &mut message) {
+            Ok(_) => {
+                rprint!("Multiplexer state before disabling channel {}: {:08b}\n", channel, message[0]);
+            },
+            Err(_) => rprint!("Failed to read multiplexer state to disable channel {}\n", channel),
+        }
+
+        message[0] &= !(1 << channel);
+        match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
+            Ok(_) => (),
+            Err(_) => rprint!("Failed to disable multiplexer channel {}\n", channel),
+        }
+    }
+
+    fn disable_all_channels(&self, board: &mut dyn rriv_board::RRIVBoard) {
+        
+        let message: [u8; 1] = [0];
+        match board.ic2_write(MULTIPLEXER_ADDRESS, &message) {
+            Ok(_) => {
+                rprint!("Disabled all multiplexer channels\n");
+            },
+            Err(_) => rprint!("Failed to disable multiplexer channels\n"),
+        }
+    }
+
+}
+
+
+
+const INDEX_TO_BYTE_CHAR: [u8; TEMPERATURE_SENSORS_ON_RING] = [b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H'];
+
+impl SensorDriver for RingMuxTemperatureDriver {
+
+    // TODO: this should come from a derived trait
+    fn get_configuration_json(&mut self) -> serde_json::Value {
+        // let sensor_id_str: [u8; 6] = core::str::from_utf8(self.get_id());
+
+        let mut sensor_name = sensor_name_from_type_id(self.get_type_id().into());
+        let sensor_name = match util::str_from_utf8(&mut sensor_name) {
+            Ok(sensor_name) => sensor_name,
+            Err(_) => "Invalid",
+        };
+        json!({
+            "id" : self.get_id(),
+            "type" : sensor_name,
+            "calibration_offset": self.special_config.calibration_offset,
+            "channels": self.special_config.channels,
+            "sensors": self.special_config.sensors
+        })
+    }
+
+    fn setup(&mut self, _board: &mut dyn rriv_board::RRIVBoard) {
+        // for i in 0..TEMPERATURE_SENSORS_ON_RING {
+        //     self.sensor_drivers[i].setup(board);
+        // }
+    }
+
+    getters!();
+
+    fn get_measured_parameter_count(&mut self) -> usize {
+        let mut channels_used = 1;
+        if self.special_config.channels > 0 {
+            channels_used = self.special_config.channels;
+        }
+        self.special_config.sensors * 2 * channels_used
+    }
+
+    fn get_measured_parameter_value(&mut self, index: usize) -> Result<f64, ()> {
+        if self.measured_parameter_values[index] == f64::MAX {
+            Err(())
+        } else {
+            Ok(self.measured_parameter_values[index])
+        }
+    }
+
+    fn get_measured_parameter_identifier(&mut self, index: usize) -> [u8; 16] {
+        let sensor_index = (index / 2) % self.special_config.sensors;
+        let _parameter_index = index % 2;
+        // let buf =
+        //     self.sensor_drivers[sensor_index].get_measured_parameter_identifier(parameter_index);
+
+        let mut buf2: [u8; 16] = [0; 16];
+        // buf2[0..10].copy_from_slice(&buf[0..10]);
+        let mut end = buf2
+                        .iter()
+                        .position(|&x| x == b'\0')
+                        .unwrap_or_else(|| 1);
+        if end >= 14 { end = 14 }
+        buf2[end] = INDEX_TO_BYTE_CHAR[sensor_index];
+        buf2[end+1] = b'\0';
+        return buf2;
+    }
+
+    fn take_measurement(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        
+        for c in 0..self.special_config.channels {
+            // Enable channel c on the multiplexer
+            self.enable_channel(c, board);
+
+            for i in 0..self.special_config.sensors {
+                // self.sensor_drivers[i].take_measurement(board);
+                // self.measured_parameter_values[c * self.special_config.sensors * 2 + i * 2] =
+                //     match self.sensor_drivers[i].get_measured_parameter_value(0) {
+                //         Ok(value) => value,
+                //         Err(_) => f64::MAX,
+                //     };
+                // self.measured_parameter_values[c * self.special_config.sensors * 2 + i * 2 + 1] =
+                //     match self.sensor_drivers[i].get_measured_parameter_value(1) {
+                //         Ok(value) => value,
+                //         Err(_) => f64::MAX,
+                //     };
+                self.measured_parameter_values[c * self.special_config.sensors * 2 + i * 2] = 22.2;
+                self.measured_parameter_values[c * self.special_config.sensors * 2 + i * 2 + 1] = 25.4;
+            }
+
+            // Disable channel c on the multiplexer
+            self.disable_all_channels(board);
+        }
+        
+        // If mux is not used
+        if self.special_config.channels == 0 {
+            for i in 0..self.special_config.sensors {
+                // self.sensor_drivers[i].take_measurement(board);
+                // self.measured_parameter_values[i * 2] =
+                //     match self.sensor_drivers[i].get_measured_parameter_value(0) {
+                //         Ok(value) => value,
+                //         Err(_) => f64::MAX,
+                //     };
+                // self.measured_parameter_values[i * 2 + 1] =
+                //     match self.sensor_drivers[i].get_measured_parameter_value(1) {
+                //         Ok(value) => value,
+                //         Err(_) => f64::MAX,
+                //     };
+                self.measured_parameter_values[i * 2] = 22.2;
+                self.measured_parameter_values[i * 2 + 1] = 25.4;
+            }
+        }
+    }
+
+    fn clear_calibration(&mut self) {
+        // for i in 0..self.sensor_drivers.len() {
+        //     self.sensor_drivers[i].clear_calibration();
+        // }
+    }
+    
+   
+
+    fn fit(&mut self, pairs: &[CalibrationPair]) -> Result<(), ()> {
+        // validate
+        if pairs.len() != 1 {
+            return Err(());
+        }
+
+        if pairs[0].values.len() < 6 {
+            // TODO: check for zeros, not for len().  len is constant
+            rprint!("not enough values to calibrate");
+            return Err(());
+        }
+
+        // fit
+        let single = &pairs[0];
+        let point = single.point;
+        let values = &single.values;
+        for i in 0..TEMPERATURE_SENSORS_ON_RING as usize {
+            let _pairs = CalibrationPair {
+                point: point,
+                values: Box::new([values[i]]),
+            };
+            // let result = self.sensor_drivers[i].fit(&[pairs]);
+            // self.special_config.calibration_offset[i] = self.sensor_drivers[i].get_calibration_offset().clone();
+            // match result {
+            //     Ok(_) => true,
+            //     Err(_) => return Err(()),
+            // };
+        }
+        Ok(())
+    }
+
+    fn update_actuators(&mut self, _board: &mut dyn rriv_board::RRIVBoard) {
+    }
+}

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -5,7 +5,7 @@ use crate::sensor_name_from_type_id;
 
 use super::types::*;
 
-const MAX_MILLIS: u32 = 65535;
+// const MAX_MILLIS: u32 = 65535;
 #[derive(Copy, Clone)]
 pub struct TimedSwitch2SpecialConfiguration {
     on_time_s: usize,
@@ -324,7 +324,7 @@ impl SensorDriver for TimedSwitch2 {
 
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
         let timestamp = board.timestamp();
-        let millis = board.millis();
+        // let millis = board.millis();
 
         let mut gpio_state = false;
         let mut toggle_state = false;
@@ -340,8 +340,8 @@ impl SensorDriver for TimedSwitch2 {
                 toggle_state = true;
                 gpio_state = true;
                 self.state = 1;
-                self.last_duty_cycle_update = millis;
-                self.duty_cycle_state = true;
+                // self.last_duty_cycle_update = millis;
+                // self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
             }
         } else if self.state == 1 {
@@ -349,27 +349,28 @@ impl SensorDriver for TimedSwitch2 {
             if self.special_config.pwm_enable {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
-            } else if self.special_config.pwm_enable {
-            // duty cycle implementation
-                let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
-                let mut new_elapsed: u32 = elapsed as u32;
-                if elapsed < 0 {
-                    // millis overflowed
-                    new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
-                }
+            } 
+            // else if self.special_config.pwm_enable {
+            // // duty cycle implementation
+            //     let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
+            //     let mut new_elapsed: u32 = elapsed as u32;
+            //     if elapsed < 0 {
+            //         // millis overflowed
+            //         new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
+            //     }
                 
-                if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
-                    toggle_state = true;
-                    gpio_state = false;
-                    self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state  = false;
-                } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
-                    toggle_state = true;
-                    gpio_state = true;
-                    self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state  = true;
-                } 
-            }
+            //     if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
+            //         toggle_state = true;
+            //         gpio_state = false;
+            //         self.last_duty_cycle_update = millis;
+            //         self.duty_cycle_state  = false;
+            //     } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
+            //         toggle_state = true;
+            //         gpio_state = true;
+            //         self.last_duty_cycle_update = millis;
+            //         self.duty_cycle_state  = true;
+            //     } 
+            // }
             // end of on_time (outer cycle)
             if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
                 defmt::println!("state is 1, toggle triggered");

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -282,6 +282,11 @@ impl SensorDriver for TimedSwitch2 {
             };
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
+        else {
+            let period_ms = (self.special_config.period * 1000.0) as u32;
+            defmt::println!("Setting PWM period to {} ms", period_ms);
+            board.write_pwm_pin_period(period_ms);
+        }
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
         self.duty_cycle_state = self.state == 1;

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -89,6 +89,19 @@ impl TimedSwitch2SpecialConfiguration {
             }
         }
 
+        match &values["pwm_type"] {
+            serde_json::Value::String(s) => {
+                let pwm_type: bool = match s.to_ascii_lowercase().as_str() {
+                    "hw" => true,
+                    "sw" => false,
+                    _ => true,
+                };
+                self.pwm_type = pwm_type;
+                return Ok(());
+            },
+            _ => {}
+        }
+
         match &values["period"] {
             serde_json::Value::Number(number) => {
                 if let Some(number) = number.as_f64() {

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -309,9 +309,12 @@ impl SensorDriver for TimedSwitch2 {
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
         else if self.special_config.pwm_enable && self.special_config.pwm_type {
-            let period_ms = (self.special_config.period * 1000.0) as u32;
+            let mut period_ms = (self.special_config.period * 1000.0) as u32;
+            if period_ms > 1000 {
+                period_ms = 1000;
+            }
             defmt::println!("Setting PWM period to {} ms", period_ms);
-            board.write_pwm_pin_period(period_ms);
+            // board.write_pwm_pin_period(period_ms);
         }
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
@@ -448,7 +451,8 @@ impl SensorDriver for TimedSwitch2 {
             "gpio_pin": self.special_config.gpio_pin,
             "period" : self.special_config.period,
             "ratio" : self.special_config.ratio,
-            "initial_state" : initial_state_str,        
+            "initial_state" : initial_state_str,  
+            "pwm_enable" : self.special_config.pwm_enable      
         })
     }
     

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -287,12 +287,12 @@ impl TimedSwitch2 {
 
 impl SensorDriver for TimedSwitch2 {
     fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
+        self.state = match self.special_config.initial_state {
+            true => 1,
+            false => 0,
+        };
         if !self.special_config.pwm_type {
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
-            self.state = match self.special_config.initial_state {
-                true => 1,
-                false => 0,
-            };
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
         else if self.special_config.pwm_enable && self.special_config.pwm_type {

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -314,7 +314,7 @@ impl SensorDriver for TimedSwitch2 {
                 period_ms = 1000;
             }
             defmt::println!("Setting PWM period to {} ms", period_ms);
-            // board.write_pwm_pin_period(period_ms);
+            board.write_pwm_pin_period(period_ms);
         }
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
@@ -364,8 +364,9 @@ impl SensorDriver for TimedSwitch2 {
         let mut toggle_state = false;
         if self.state == 0 {
             // heater is off
-            if self.special_config.pwm_enable && self.special_config.pwm_type {
-                // chip produced pwm on pin 1 only
+            let hardware_pwm = self.special_config.pwm_enable && self.special_config.pwm_type;
+            if hardware_pwm {
+                // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty(0);
             }
 
@@ -380,7 +381,8 @@ impl SensorDriver for TimedSwitch2 {
             }
         } else if self.state == 1 {
             // heater is on
-            if self.special_config.pwm_enable && self.special_config.pwm_type {
+            let hardware_pwm = self.special_config.pwm_enable && self.special_config.pwm_type;
+            if hardware_pwm {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
             } 

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -365,7 +365,8 @@ impl SensorDriver for TimedSwitch2 {
         if self.state == 0 {
             // heater is off
             let hardware_pwm = self.special_config.pwm_enable && self.special_config.pwm_type;
-            if hardware_pwm {
+            defmt::println!("{}", hardware_pwm);
+            if hardware_pwm == true {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty(0);
             }

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -5,7 +5,7 @@ use crate::sensor_name_from_type_id;
 
 use super::types::*;
 
-// const MAX_MILLIS: u32 = 65535;
+const MAX_MILLIS: u32 = 65535;
 #[derive(Copy, Clone)]
 pub struct TimedSwitch2SpecialConfiguration {
     on_time_s: usize,
@@ -14,6 +14,7 @@ pub struct TimedSwitch2SpecialConfiguration {
     initial_state: bool, // 'on' 'off'
     // polarity // 'low_is_on', 'high_is_on'
     pwm_enable: bool,
+    pwm_type: bool,
     period: f32,
     ratio: f32,
     _empty: [u8; 13],
@@ -195,6 +196,17 @@ impl TimedSwitch2SpecialConfiguration {
             }
         }
 
+        let s = match &value["pwm_type"] {
+            serde_json::Value::String(s) => s.as_str(),
+            _ => "hw"
+        };
+        
+        let pwm_type: bool = match s.to_ascii_lowercase().as_str() {
+            "hw" => true,
+            "sw" => false,
+            _ => true,
+        };
+
         let mut period: f32 = 10.0;
         match &value["period"] {
             serde_json::Value::Number(number) => {
@@ -228,6 +240,7 @@ impl TimedSwitch2SpecialConfiguration {
             gpio_pin,
             initial_state,
             pwm_enable,
+            pwm_type,
             period,
             ratio,
             _empty: [b'\0'; 13],
@@ -274,7 +287,7 @@ impl TimedSwitch2 {
 
 impl SensorDriver for TimedSwitch2 {
     fn setup(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
-        if ! self.special_config.pwm_enable {
+        if !self.special_config.pwm_type {
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
             self.state = match self.special_config.initial_state {
                 true => 1,
@@ -282,7 +295,7 @@ impl SensorDriver for TimedSwitch2 {
             };
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
-        else {
+        else if self.special_config.pwm_enable && self.special_config.pwm_type {
             let period_ms = (self.special_config.period * 1000.0) as u32;
             defmt::println!("Setting PWM period to {} ms", period_ms);
             board.write_pwm_pin_period(period_ms);
@@ -329,13 +342,13 @@ impl SensorDriver for TimedSwitch2 {
 
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
         let timestamp = board.timestamp();
-        // let millis = board.millis();
+        let millis = board.millis();
 
         let mut gpio_state = false;
         let mut toggle_state = false;
         if self.state == 0 {
             // heater is off
-            if self.special_config.pwm_enable {
+            if self.special_config.pwm_enable && self.special_config.pwm_type {
                 // chip produced pwm on pin 1 only
                 board.write_pwm_pin_duty(0);
             }
@@ -345,37 +358,37 @@ impl SensorDriver for TimedSwitch2 {
                 toggle_state = true;
                 gpio_state = true;
                 self.state = 1;
-                // self.last_duty_cycle_update = millis;
-                // self.duty_cycle_state = true;
+                self.last_duty_cycle_update = millis;
+                self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
             }
         } else if self.state == 1 {
             // heater is on
-            if self.special_config.pwm_enable {
+            if self.special_config.pwm_enable && self.special_config.pwm_type {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
             } 
-            // else if self.special_config.pwm_enable {
-            // // duty cycle implementation
-            //     let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
-            //     let mut new_elapsed: u32 = elapsed as u32;
-            //     if elapsed < 0 {
-            //         // millis overflowed
-            //         new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
-            //     }
+            else if self.special_config.pwm_enable && !self.special_config.pwm_type {
+            // duty cycle implementation
+                let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
+                let mut new_elapsed: u32 = elapsed as u32;
+                if elapsed < 0 {
+                    // millis overflowed
+                    new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
+                }
                 
-            //     if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
-            //         toggle_state = true;
-            //         gpio_state = false;
-            //         self.last_duty_cycle_update = millis;
-            //         self.duty_cycle_state  = false;
-            //     } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
-            //         toggle_state = true;
-            //         gpio_state = true;
-            //         self.last_duty_cycle_update = millis;
-            //         self.duty_cycle_state  = true;
-            //     } 
-            // }
+                if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
+                    toggle_state = true;
+                    gpio_state = false;
+                    self.last_duty_cycle_update = millis;
+                    self.duty_cycle_state  = false;
+                } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
+                    toggle_state = true;
+                    gpio_state = true;
+                    self.last_duty_cycle_update = millis;
+                    self.duty_cycle_state  = true;
+                } 
+            }
             // end of on_time (outer cycle)
             if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
                 defmt::println!("state is 1, toggle triggered");

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -300,13 +300,17 @@ impl TimedSwitch2 {
     fn apply_hardware_pwm(&self, board: &mut dyn rriv_board::RRIVBoard){
         let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
 
+        defmt::println!("applying hardware pwm");
         if hardware_pwm {
+            defmt::println!("really applying hardware pwm");
             if self.state == 0 {
                 // chip produces pwm on pin 1 only
-                board.write_pwm_pin_duty(0);        
+                board.write_pwm_pin_duty(0);
+                defmt::println!("applied hardware pwm 0");
             } else if self.state == 1 {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
+                defmt::println!("applied hardware pwm {}", (255_f32 * self.special_config.ratio) as u8);
             }
         }
     }
@@ -338,6 +342,7 @@ impl SensorDriver for TimedSwitch2 {
         self.duty_cycle_on_time = (self.special_config.period * self.special_config.ratio * 1000.0) as u32;
         self.duty_cycle_off_time = (self.special_config.period * 1000.0) as u32 - self.duty_cycle_on_time;
         // defmt::println!("Initial state is set to {}", self.state);
+        self.apply_hardware_pwm(board);
     }
 
     fn get_requested_gpios(&self) -> super::resources::gpio::GpioRequest {

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -74,7 +74,7 @@ impl TimedSwitch2SpecialConfiguration {
                     _ => return Err("invalid initial state"),
                 };
                 self.initial_state = initial_state;
-                return Ok(());
+                return Ok(()); // TODO: remove this, apperas to be an error
             },
             _ => {}
         };
@@ -97,7 +97,7 @@ impl TimedSwitch2SpecialConfiguration {
                     _ => true,
                 };
                 self.hardware_pwm = hardware_pwm;
-                return Ok(());
+                return Ok(());  // TODO: remove this, apperas to be an error
             },
             _ => {}
         }

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -14,7 +14,7 @@ pub struct TimedSwitch2SpecialConfiguration {
     initial_state: bool, // 'on' 'off'
     // polarity // 'low_is_on', 'high_is_on'
     pwm_enable: bool,
-    pwm_type: bool,
+    hardware_pwm: bool,
     period: f32,
     ratio: f32,
     _empty: [u8; 13],
@@ -89,14 +89,14 @@ impl TimedSwitch2SpecialConfiguration {
             }
         }
 
-        match &values["pwm_type"] {
+        match &values["hardware_pwm"] {
             serde_json::Value::String(s) => {
-                let pwm_type: bool = match s.to_ascii_lowercase().as_str() {
+                let hardware_pwm: bool = match s.to_ascii_lowercase().as_str() {
                     "hw" => true,
                     "sw" => false,
                     _ => true,
                 };
-                self.pwm_type = pwm_type;
+                self.hardware_pwm = hardware_pwm;
                 return Ok(());
             },
             _ => {}
@@ -209,12 +209,12 @@ impl TimedSwitch2SpecialConfiguration {
             }
         }
 
-        let s = match &value["pwm_type"] {
+        let s = match &value["hardware_pwm"] {
             serde_json::Value::String(s) => s.as_str(),
             _ => "hw"
         };
         
-        let pwm_type: bool = match s.to_ascii_lowercase().as_str() {
+        let hardware_pwm: bool = match s.to_ascii_lowercase().as_str() {
             "hw" => true,
             "sw" => false,
             _ => true,
@@ -253,7 +253,7 @@ impl TimedSwitch2SpecialConfiguration {
             gpio_pin,
             initial_state,
             pwm_enable,
-            pwm_type,
+            hardware_pwm,
             period,
             ratio,
             _empty: [b'\0'; 13],
@@ -304,11 +304,11 @@ impl SensorDriver for TimedSwitch2 {
             true => 1,
             false => 0,
         };
-        if !self.special_config.pwm_type {
+        if !self.special_config.hardware_pwm {
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
         }
-        else if self.special_config.pwm_enable && self.special_config.pwm_type {
+        else if self.special_config.pwm_enable && self.special_config.hardware_pwm {
             let mut period_ms = (self.special_config.period * 1000.0) as u32;
             if period_ms > 1000 {
                 period_ms = 1000;
@@ -364,7 +364,7 @@ impl SensorDriver for TimedSwitch2 {
         let mut toggle_state = false;
         if self.state == 0 {
             // heater is off
-            let hardware_pwm = self.special_config.pwm_enable && self.special_config.pwm_type;
+            let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
             // defmt::println!("{}", hardware_pwm);
             if hardware_pwm == true {
                 // chip produces pwm on pin 1 only
@@ -382,12 +382,12 @@ impl SensorDriver for TimedSwitch2 {
             }
         } else if self.state == 1 {
             // heater is on
-            let hardware_pwm = self.special_config.pwm_enable && self.special_config.pwm_type;
+            let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
             if hardware_pwm {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
             } 
-            else if self.special_config.pwm_enable && !self.special_config.pwm_type {
+            else if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
             // duty cycle implementation
                 let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
                 let mut new_elapsed: u32 = elapsed as u32;
@@ -455,7 +455,8 @@ impl SensorDriver for TimedSwitch2 {
             "period" : self.special_config.period,
             "ratio" : self.special_config.ratio,
             "initial_state" : initial_state_str,  
-            "pwm_enable" : self.special_config.pwm_enable      
+            "pwm_enable" : self.special_config.pwm_enable,
+            "hardware_pwm" : self.special_config.hardware_pwm
         })
     }
     

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -3,8 +3,6 @@ use serde_json::json;
 
 use crate::sensor_name_from_type_id;
 
-
-
 use super::types::*;
 
 const MAX_MILLIS: u32 = 65535;
@@ -76,6 +74,7 @@ impl TimedSwitch2SpecialConfiguration {
                     _ => return Err("invalid initial state"),
                 };
                 self.initial_state = initial_state;
+                return Ok(());
             },
             _ => {}
         };
@@ -98,6 +97,7 @@ impl TimedSwitch2SpecialConfiguration {
                     _ => true,
                 };
                 self.hardware_pwm = hardware_pwm;
+                return Ok(());
             },
             _ => {}
         }
@@ -296,11 +296,6 @@ impl TimedSwitch2 {
             duty_cycle_off_time: 0,
         }
     }
-
-    /// Helper: true when this driver is configured to drive hardware PWM on the pin.
-    fn is_hardware_pwm(&self) -> bool {
-        self.special_config.pwm_enable && self.special_config.hardware_pwm
-    }
 }
 
 impl SensorDriver for TimedSwitch2 {
@@ -309,30 +304,18 @@ impl SensorDriver for TimedSwitch2 {
             true => 1,
             false => 0,
         };
-
         if !self.special_config.hardware_pwm {
-            // Software-driven GPIO (with or without sw PWM): set pin mode and write initial level.
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
-        } else if self.is_hardware_pwm() {
-            // Hardware PWM path. Configure period, then force a known duty so we don't
-            // emit an undefined PWM signal between boot and the first update_actuators call.
+        }
+        else if self.special_config.pwm_enable && self.special_config.hardware_pwm {
             let mut period_ms = (self.special_config.period * 1000.0) as u32;
             if period_ms > 1000 {
                 period_ms = 1000;
             }
             defmt::println!("Setting PWM period to {} ms", period_ms);
             board.write_pwm_pin_period(period_ms);
-
-            // Initialize duty based on initial state so the pin doesn't pulse before
-            // update_actuators runs for the first time.
-            if self.state == 1 {
-                board.write_pwm_pin_duty((255_f32 * self.special_config.ratio) as u8);
-            } else {
-                board.write_pwm_pin_duty(0);
-            }
         }
-
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
         self.duty_cycle_state = self.state == 1;
@@ -376,87 +359,69 @@ impl SensorDriver for TimedSwitch2 {
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
         let timestamp = board.timestamp();
         let millis = board.millis();
-        let hardware_pwm = self.is_hardware_pwm();
+        let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
 
         let mut gpio_state = false;
         let mut toggle_state = false;
-
         if self.state == 0 {
-            // Off phase. Make sure PWM duty is 0 every pass while we're off, so
-            // we never silently leak a pulse if duty was set elsewhere.
-            if hardware_pwm {
+            // heater is off
+            // defmt::println!("{}", hardware_pwm);
+            if hardware_pwm == true {
+                // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty(0);
             }
 
             if timestamp - self.special_config.off_time_s as i64 > self.last_state_updated_at {
-                defmt::println!("state is 0, toggle triggered (off -> on)");
+                defmt::println!("state is 0, toggle triggered");
                 toggle_state = true;
                 gpio_state = true;
                 self.state = 1;
                 self.last_duty_cycle_update = millis;
                 self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
-
-                // Engage PWM immediately on the off->on transition so we don't wait
-                // a full update cycle to start driving the heater.
-                if hardware_pwm {
-                    board.write_pwm_pin_duty((255_f32 * self.special_config.ratio) as u8);
-                }
             }
         } else if self.state == 1 {
-            // On phase.
+            // heater is on
             if hardware_pwm {
-                // Hardware PWM: keep the duty commanded high while we're in the on phase.
-                board.write_pwm_pin_duty((255_f32 * self.special_config.ratio) as u8);
-            } else if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
-                // Software duty-cycle implementation on a regular GPIO.
+                // chip produces pwm on pin 1 only
+                board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
+            } 
+            else if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
+            // duty cycle implementation
                 let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
                 let mut new_elapsed: u32 = elapsed as u32;
                 if elapsed < 0 {
                     // millis overflowed
                     new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
                 }
-
+                
                 if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
                     toggle_state = true;
                     gpio_state = false;
                     self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state = false;
+                    self.duty_cycle_state  = false;
                 } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
                     toggle_state = true;
                     gpio_state = true;
                     self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state = true;
-                }
+                    self.duty_cycle_state  = true;
+                } 
             }
-
-            // End of on_time (outer cycle): transition on -> off.
+            // end of on_time (outer cycle)
             if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
-                defmt::println!("state is 1, toggle triggered (on -> off)");
+                defmt::println!("state is 1, toggle triggered");
                 toggle_state = true;
                 gpio_state = false;
                 self.state = 0;
                 self.last_state_updated_at = timestamp;
-
-                // CRITICAL: kill the PWM duty in the same call that flips the state
-                // to 0. Otherwise the duty stays high until the next update_actuators
-                // pass, which is what was causing PWM to keep firing while the data
-                // log already read 0.
-                if hardware_pwm {
-                    board.write_pwm_pin_duty(0);
-                }
             }
+
         }
 
-        // Only write to the GPIO directly when we are NOT using hardware PWM on this pin.
-        // For hardware PWM the pin is owned by the timer peripheral; writing it as a
-        // GPIO either fights the peripheral or is silently dropped, and either way it
-        // doesn't actually stop the PWM signal.
-        if toggle_state && !hardware_pwm {
-            defmt::println!("toggled gpio to {}", gpio_state);
+        if toggle_state && !hardware_pwm { 
+            defmt::println!("toggled to {}", gpio_state);
+            // rprintln!("on_time: {}, ratio: {}, period: {}\nduty cycle on time: {}, off time: {}", self.special_config.on_time_s, self.special_config.ratio, self.special_config.period, self.duty_cycle_on_time, self.duty_cycle_off_time);
             board.write_gpio_pin(self.special_config.gpio_pin, gpio_state);
-        } else if toggle_state {
-            defmt::println!("toggled (hw pwm) state -> {}", self.state);
         }
     }
     

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -17,7 +17,7 @@ pub struct TimedSwitch2SpecialConfiguration {
     hardware_pwm: bool,
     period: f32,
     ratio: f32,
-    // _empty: [u8; 13],
+    _empty: [u8; 12],
 }
 
 impl TimedSwitch2SpecialConfiguration {
@@ -256,7 +256,7 @@ impl TimedSwitch2SpecialConfiguration {
             hardware_pwm,
             period,
             ratio,
-            // _empty: [b'\0'; 13],
+            _empty: [b'\0'; 12],
         } )
     }
 

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -441,7 +441,7 @@ impl SensorDriver for TimedSwitch2 {
         }
 
         if toggle_state && !hardware_pwm { 
-            defmt::println!("toggled to {}", gpio_state);
+            defmt::println!("toggled switch to {}", gpio_state);
             // rprintln!("on_time: {}, ratio: {}, period: {}\nduty cycle on time: {}, off time: {}", self.special_config.on_time_s, self.special_config.ratio, self.special_config.period, self.duty_cycle_on_time, self.duty_cycle_off_time);
             board.write_gpio_pin(self.special_config.gpio_pin, gpio_state);
         }

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -296,6 +296,20 @@ impl TimedSwitch2 {
             duty_cycle_off_time: 0,
         }
     }
+
+    fn apply_hardware_pwm(&self, board: &mut dyn rriv_board::RRIVBoard){
+        let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
+
+        if hardware_pwm {
+            if self.state == 0 {
+                // chip produces pwm on pin 1 only
+                board.write_pwm_pin_duty(0);        
+            } else if self.state == 1 {
+                // chip produces pwm on pin 1 only
+                board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
+            }
+        }
+    }
 }
 
 impl SensorDriver for TimedSwitch2 {
@@ -363,13 +377,10 @@ impl SensorDriver for TimedSwitch2 {
 
         let mut gpio_state = false;
         let mut toggle_state = false;
+        self.apply_hardware_pwm(board);
         if self.state == 0 {
             // heater is off
             // defmt::println!("{}", hardware_pwm);
-            if hardware_pwm == true {
-                // chip produces pwm on pin 1 only
-                board.write_pwm_pin_duty(0);
-            }
 
             if timestamp - self.special_config.off_time_s as i64 > self.last_state_updated_at {
                 defmt::println!("state is 0, toggle triggered");
@@ -379,14 +390,13 @@ impl SensorDriver for TimedSwitch2 {
                 self.last_duty_cycle_update = millis;
                 self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
+                self.apply_hardware_pwm(board);
             }
         } else if self.state == 1 {
             // heater is on
-            if hardware_pwm {
-                // chip produces pwm on pin 1 only
-                board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
-            } 
-            else if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
+
+            //software pwm
+            if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
             // duty cycle implementation
                 let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
                 let mut new_elapsed: u32 = elapsed as u32;
@@ -414,6 +424,7 @@ impl SensorDriver for TimedSwitch2 {
                 gpio_state = false;
                 self.state = 0;
                 self.last_state_updated_at = timestamp;
+                self.apply_hardware_pwm(board);
             }
 
         }

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -74,7 +74,6 @@ impl TimedSwitch2SpecialConfiguration {
                     _ => return Err("invalid initial state"),
                 };
                 self.initial_state = initial_state;
-                return Ok(());
             },
             _ => {}
         };
@@ -97,7 +96,6 @@ impl TimedSwitch2SpecialConfiguration {
                     _ => true,
                 };
                 self.hardware_pwm = hardware_pwm;
-                return Ok(());
             },
             _ => {}
         }
@@ -296,6 +294,11 @@ impl TimedSwitch2 {
             duty_cycle_off_time: 0,
         }
     }
+
+    /// Helper: true when this driver is configured to drive hardware PWM on the pin.
+    fn is_hardware_pwm(&self) -> bool {
+        self.special_config.pwm_enable && self.special_config.hardware_pwm
+    }
 }
 
 impl SensorDriver for TimedSwitch2 {
@@ -304,18 +307,30 @@ impl SensorDriver for TimedSwitch2 {
             true => 1,
             false => 0,
         };
+
         if !self.special_config.hardware_pwm {
+            // Software-driven GPIO (with or without sw PWM): set pin mode and write initial level.
             board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
             board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
-        }
-        else if self.special_config.pwm_enable && self.special_config.hardware_pwm {
+        } else if self.is_hardware_pwm() {
+            // Hardware PWM path. Configure period, then force a known duty so we don't
+            // emit an undefined PWM signal between boot and the first update_actuators call.
             let mut period_ms = (self.special_config.period * 1000.0) as u32;
             if period_ms > 1000 {
                 period_ms = 1000;
             }
             defmt::println!("Setting PWM period to {} ms", period_ms);
             board.write_pwm_pin_period(period_ms);
+
+            // Initialize duty based on initial state so the pin doesn't pulse before
+            // update_actuators runs for the first time.
+            if self.state == 1 {
+                board.write_pwm_pin_duty((255_f32 * self.special_config.ratio) as u8);
+            } else {
+                board.write_pwm_pin_duty(0);
+            }
         }
+
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
         self.duty_cycle_state = self.state == 1;
@@ -359,70 +374,87 @@ impl SensorDriver for TimedSwitch2 {
     fn update_actuators(&mut self, board: &mut dyn rriv_board::RRIVBoard) {
         let timestamp = board.timestamp();
         let millis = board.millis();
+        let hardware_pwm = self.is_hardware_pwm();
 
         let mut gpio_state = false;
         let mut toggle_state = false;
+
         if self.state == 0 {
-            // heater is off
-            let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
-            // defmt::println!("{}", hardware_pwm);
-            if hardware_pwm == true {
-                // chip produces pwm on pin 1 only
+            // Off phase. Make sure PWM duty is 0 every pass while we're off, so
+            // we never silently leak a pulse if duty was set elsewhere.
+            if hardware_pwm {
                 board.write_pwm_pin_duty(0);
             }
 
             if timestamp - self.special_config.off_time_s as i64 > self.last_state_updated_at {
-                defmt::println!("state is 0, toggle triggered");
+                defmt::println!("state is 0, toggle triggered (off -> on)");
                 toggle_state = true;
                 gpio_state = true;
                 self.state = 1;
                 self.last_duty_cycle_update = millis;
                 self.duty_cycle_state = true;
                 self.last_state_updated_at = timestamp;
+
+                // Engage PWM immediately on the off->on transition so we don't wait
+                // a full update cycle to start driving the heater.
+                if hardware_pwm {
+                    board.write_pwm_pin_duty((255_f32 * self.special_config.ratio) as u8);
+                }
             }
         } else if self.state == 1 {
-            // heater is on
-            let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
+            // On phase.
             if hardware_pwm {
-                // chip produces pwm on pin 1 only
-                board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
-            } 
-            else if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
-            // duty cycle implementation
+                // Hardware PWM: keep the duty commanded high while we're in the on phase.
+                board.write_pwm_pin_duty((255_f32 * self.special_config.ratio) as u8);
+            } else if self.special_config.pwm_enable && !self.special_config.hardware_pwm {
+                // Software duty-cycle implementation on a regular GPIO.
                 let elapsed: i32 = millis as i32 - self.last_duty_cycle_update as i32;
                 let mut new_elapsed: u32 = elapsed as u32;
                 if elapsed < 0 {
                     // millis overflowed
                     new_elapsed = MAX_MILLIS - self.last_duty_cycle_update + millis;
                 }
-                
+
                 if self.duty_cycle_state == true && new_elapsed > self.duty_cycle_on_time {
                     toggle_state = true;
                     gpio_state = false;
                     self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state  = false;
+                    self.duty_cycle_state = false;
                 } else if self.duty_cycle_state == false && new_elapsed > self.duty_cycle_off_time {
                     toggle_state = true;
                     gpio_state = true;
                     self.last_duty_cycle_update = millis;
-                    self.duty_cycle_state  = true;
-                } 
+                    self.duty_cycle_state = true;
+                }
             }
-            // end of on_time (outer cycle)
+
+            // End of on_time (outer cycle): transition on -> off.
             if timestamp - self.special_config.on_time_s as i64 > self.last_state_updated_at {
-                defmt::println!("state is 1, toggle triggered");
+                defmt::println!("state is 1, toggle triggered (on -> off)");
                 toggle_state = true;
                 gpio_state = false;
                 self.state = 0;
                 self.last_state_updated_at = timestamp;
-            }
 
+                // CRITICAL: kill the PWM duty in the same call that flips the state
+                // to 0. Otherwise the duty stays high until the next update_actuators
+                // pass, which is what was causing PWM to keep firing while the data
+                // log already read 0.
+                if hardware_pwm {
+                    board.write_pwm_pin_duty(0);
+                }
+            }
         }
 
-        if toggle_state { 
-            defmt::println!("toggled to {}", gpio_state);
-            // rprintln!("on_time: {}, ratio: {}, period: {}\nduty cycle on time: {}, off time: {}", self.special_config.on_time_s, self.special_config.ratio, self.special_config.period, self.duty_cycle_on_time, self.duty_cycle_off_time);
+        // Only write to the GPIO directly when we are NOT using hardware PWM on this pin.
+        // For hardware PWM the pin is owned by the timer peripheral; writing it as a
+        // GPIO either fights the peripheral or is silently dropped, and either way it
+        // doesn't actually stop the PWM signal.
+        if toggle_state && !hardware_pwm {
+            defmt::println!("toggled gpio to {}", gpio_state);
             board.write_gpio_pin(self.special_config.gpio_pin, gpio_state);
+        } else if toggle_state {
+            defmt::println!("toggled (hw pwm) state -> {}", self.state);
         }
     }
     

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -278,6 +278,7 @@ pub struct TimedSwitch2 {
     last_duty_cycle_update: u32,
     duty_cycle_on_time: u32,
     duty_cycle_off_time: u32,
+    last_pwm: u8
 }
 
 impl TimedSwitch2 {
@@ -294,24 +295,29 @@ impl TimedSwitch2 {
             last_duty_cycle_update: 0,
             duty_cycle_on_time: 0,
             duty_cycle_off_time: 0,
+            last_pwm: u8::MAX
         }
     }
 
-    fn apply_hardware_pwm(&self, board: &mut dyn rriv_board::RRIVBoard){
-        let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
+    fn apply_hardware_pwm(&mut self, board: &mut dyn rriv_board::RRIVBoard){
+        // let hardware_pwm = self.special_config.pwm_enable && self.special_config.hardware_pwm;
+        // defmt::println!("pwm config {} {}", self.special_config.pwm_enable, self.special_config.hardware_pwm);
+        let hardware_pwm = true;  //TODO something is wrong here.  dfmt line above shows false false, why?  debugger shows true
 
-        defmt::println!("applying hardware pwm");
+        // chip produces pwm on pin 1 only
         if hardware_pwm {
-            defmt::println!("really applying hardware pwm");
+            let mut pwm = 0;
             if self.state == 0 {
-                // chip produces pwm on pin 1 only
-                board.write_pwm_pin_duty(0);
-                defmt::println!("applied hardware pwm 0");
+                pwm = 0;
             } else if self.state == 1 {
-                // chip produces pwm on pin 1 only
-                board.write_pwm_pin_duty( (255_f32 * self.special_config.ratio) as u8);
-                defmt::println!("applied hardware pwm {}", (255_f32 * self.special_config.ratio) as u8);
+                pwm = (255_f32 * self.special_config.ratio) as u8;
             }
+            if pwm != self.last_pwm {
+                board.write_pwm_pin_duty(pwm);
+                self.last_pwm = pwm;
+                defmt::println!("applied hardware pwm {}", self.last_pwm);
+            }
+           
         }
     }
 }

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use crate::sensor_name_from_type_id;
 
 
+
 use super::types::*;
 
 const MAX_MILLIS: u32 = 65535;

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -328,18 +328,18 @@ impl SensorDriver for TimedSwitch2 {
             true => 1,
             false => 0,
         };
-        if !self.special_config.hardware_pwm {
-            board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
-            board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
-        }
-        else if self.special_config.pwm_enable && self.special_config.hardware_pwm {
+        // if !self.special_config.hardware_pwm {
+        //     board.set_gpio_pin_mode(self.special_config.gpio_pin, GpioMode::PushPullOutput);
+        //     board.write_gpio_pin(self.special_config.gpio_pin, self.state == 1);
+        // }
+        // else if self.special_config.pwm_enable && self.special_config.hardware_pwm {
             let mut period_ms = (self.special_config.period * 1000.0) as u32;
             if period_ms > 1000 {
                 period_ms = 1000;
             }
             defmt::println!("Setting PWM period to {} ms", period_ms);
             board.write_pwm_pin_period(period_ms);
-        }
+        // }
         let timestamp = board.timestamp();
         self.last_state_updated_at = timestamp;
         self.duty_cycle_state = self.state == 1;

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -365,7 +365,7 @@ impl SensorDriver for TimedSwitch2 {
         if self.state == 0 {
             // heater is off
             let hardware_pwm = self.special_config.pwm_enable && self.special_config.pwm_type;
-            defmt::println!("{}", hardware_pwm);
+            // defmt::println!("{}", hardware_pwm);
             if hardware_pwm == true {
                 // chip produces pwm on pin 1 only
                 board.write_pwm_pin_duty(0);

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 
 use crate::sensor_name_from_type_id;
 
+
 use super::types::*;
 
 const MAX_MILLIS: u32 = 65535;

--- a/src/datalogger/src/drivers/timed_switch_2.rs
+++ b/src/datalogger/src/drivers/timed_switch_2.rs
@@ -17,7 +17,7 @@ pub struct TimedSwitch2SpecialConfiguration {
     hardware_pwm: bool,
     period: f32,
     ratio: f32,
-    _empty: [u8; 13],
+    // _empty: [u8; 13],
 }
 
 impl TimedSwitch2SpecialConfiguration {
@@ -256,7 +256,7 @@ impl TimedSwitch2SpecialConfiguration {
             hardware_pwm,
             period,
             ratio,
-            _empty: [b'\0'; 13],
+            // _empty: [b'\0'; 13],
         } )
     }
 

--- a/src/datalogger/src/drivers/types.rs
+++ b/src/datalogger/src/drivers/types.rs
@@ -93,11 +93,12 @@ pub trait SensorDriver {
         GpioRequest::none()
     }
 
+    #[allow(unused_variables)]
     fn receive_modbus(&mut self, adu: modbus_core::rtu::ResponseAdu){
         // most drivers don't need to receive modbus
     }
 
-    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str>{ Ok(()) }
+    fn update(&mut self, values: serde_json::Value) -> Result<(),&'static str>;
 
 }
 

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -730,12 +730,6 @@ impl DataLogger {
     }
 
     fn write_last_measurement_to_serial(&mut self, board: &mut impl rriv_board::RRIVBoard) {
-        // first output the column headers
-        match self.serial_tx_mode {
-            DataLoggerSerialTxMode::Interactive => self.write_column_headers_to_serial(board),
-            _ => {}
-        }
-
         // then output the last measurement values
         match self.serial_tx_mode {
             DataLoggerSerialTxMode::Watch => self.write_measured_parameters_to_serial(board),

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -443,14 +443,12 @@ impl DataLogger {
                                     Sdi12Command::HA => {
                                         let mut total_measurements_count = 0;
 
-                                        // for i in 0 .. self.sensor_drivers.len() {
-                                        //     if let Some(ref mut driver) = self.sensor_drivers[i] {
-                                        //         let driver_measurements = driver.get_measured_parameter_count();
-                                        //         total_measurements_count = total_measurements_count + driver_measurements;
-                                        //     }
-                                        // }
-
-                                        total_measurements_count = 17;
+                                        for i in 0 .. self.sensor_drivers.len() {
+                                            if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                                let driver_measurements = driver.get_measured_parameter_count();
+                                                total_measurements_count = total_measurements_count + driver_measurements;
+                                            }
+                                        }
 
                                         let measurement_time = 5; // 5 seconds approximate for now
                                         defmt::println!("total_measurements: {}", total_measurements_count);

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -497,8 +497,14 @@ impl DataLogger {
                                             let index = index.unwrap() as usize;
                                             defmt::println!("index {}", index);
 
+                                            let total_measurements = sdi12_service.get_total_measurements();
                                             let start = index * MEASUREMENTS_IN_PAYLOAD as usize;
-                                            let end = start + min(MEASUREMENTS_IN_PAYLOAD as usize, sdi12_service.get_total_measurements() - start);
+                                            if start > total_measurements {
+                                                defmt::println!("SDI12: error, data request out of range");
+                                                return;
+                                            }
+                                            defmt::println!("total {}, start {}", total_measurements, start);
+                                            let end = start + min(MEASUREMENTS_IN_PAYLOAD as usize, total_measurements - start);
                                             for i in start..end {
                                                 data_send[i-start] = sdi12_service.get_data(i);
                                             }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -555,9 +555,6 @@ impl DataLogger {
                             }
                         }
                     }
-                    // for i in 0..17 {
-                    //     sdi12_service.fill_data(i, (i + 1) as f64 / 10.0);
-                    // }
 
                     board.usb_serial_send(format_args!("SDI12: measurement ready\n"));
                 }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -531,26 +531,27 @@ impl DataLogger {
                 if take_measurement {
                     board.usb_serial_send(format_args!("SDI12: taking measurement\n"));
 
-                    // self.measure_sensor_values(board);
+                    self.measure_sensor_values(board);
 
                     let sdi12_service =  self.sdi12_service.as_mut().unwrap();
 
-                    // let mut measurement_index = 0;
-                    // for i in 0 .. self.sensor_drivers.len() {
-                    //     if let Some(ref mut driver) = self.sensor_drivers[i] {
-                    //         for j in 0..driver.get_measured_parameter_count() {
-                    //             let value = match driver.get_measured_parameter_value(j) {
-                    //                 Ok(value) => value,
-                    //                 Err(_) => f64::MAX,
-                    //             };
-                    //             sdi12_service.fill_data(measurement_index, value);
-                    //             measurement_index = measurement_index + 1;
-                    //         }
-                    //     }
-                    // }
-                    for i in 0..17 {
-                        sdi12_service.fill_data(i, (i + 1) as f64 / 10.0);
+                    let mut measurement_index = 0;
+                    for i in 0 .. self.sensor_drivers.len() {
+                        if let Some(ref mut driver) = self.sensor_drivers[i] {
+                            for j in 0..driver.get_measured_parameter_count() {
+                                let value = match driver.get_measured_parameter_value(j) {
+                                    Ok(value) => value,
+                                    Err(_) => f64::MAX,
+                                };
+                                sdi12_service.fill_data(measurement_index, value);
+                                // defmt::println!("data[{}] = {}", measurement_index, value);
+                                measurement_index = measurement_index + 1;
+                            }
+                        }
                     }
+                    // for i in 0..17 {
+                    //     sdi12_service.fill_data(i, (i + 1) as f64 / 10.0);
+                    // }
 
                     board.usb_serial_send(format_args!("SDI12: measurement ready\n"));
                 }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -3,7 +3,9 @@
 mod datalogger;
 mod services;
 
+use core::f64;
 use core::i16::MAX;
+use core::cmp::min;
 
 use datalogger::commands::*;
 use datalogger::payloads::*;
@@ -20,6 +22,7 @@ use crate::datalogger::error::hardware_error_text;
 use crate::datalogger::helper;
 use crate::datalogger::modes::DataLoggerMode;
 use crate::datalogger::modes::DataLoggerSerialTxMode;
+use crate::services::sdi12_service::{Sdi12Command, MEASUREMENTS_IN_PAYLOAD};
 use crate::{protocol::responses, services::*, telemetry::telemeters::{Telemeter}};
 use alloc::boxed::Box;
 
@@ -51,6 +54,7 @@ pub struct DataLogger {
     lorawan_telemeter: Option<telemetry::telemeters::lorawan::RakWireless3172>,
     modbus_telemeter: Option<telemetry::telemeters::modbus::ModBusRTU>,
     modbus_service: Option<modbus_service::ModbusByteProcessor>,
+    sdi12_service: Option<sdi12_service::Sdi12RxProcessor>,
 
     // measurement cycle
     completed_bursts: u8,
@@ -74,7 +78,8 @@ impl DataLogger {
             modbus_telemeter: None,
             completed_bursts: 0,
             readings_completed_in_current_burst: 0,
-            modbus_service: None
+            modbus_service: None,
+            sdi12_service: None,
         }
     }
 
@@ -135,6 +140,9 @@ impl DataLogger {
         usart_service::setup(board);
         self.modbus_service = Some(modbus_service::ModbusByteProcessor::new());
         modbus_service::setup(board);
+
+        let sdi12_gpio = 5;
+        self.sdi12_service = Some(sdi12_service::Sdi12RxProcessor::new(sdi12_gpio));
 
         // read all the sensors from EEPROM
         let registry = get_registry();
@@ -200,6 +208,9 @@ impl DataLogger {
                 // if we are launching into field mode, write column headers to a new file
                 self.write_column_headers_to_storage(board);
             },
+            DataLoggerMode::SDI12 => {
+                sdi12_service::setup(board, 5);
+            }
             _ => {
                 if self.settings.toggles.enable_interactive_logging() {
                     self.write_column_headers_to_storage(board);
@@ -346,6 +357,7 @@ impl DataLogger {
         //
         // Do the measurement cycle
         //
+        // defmt::println!("Current mode: {}", datalogger::modes::mode_text(&self.mode));
 
         match self.mode {
             DataLoggerMode::Interactive => {
@@ -412,6 +424,138 @@ impl DataLogger {
                 // this block is processed when we start up, don't get an interactive mode interrupt, and are in HibernateUntil mode
                 // or when we have just entered this mode
                 // TODO: hibernate until the requested wake time
+            }
+            DataLoggerMode::SDI12 => {
+                let mut take_measurement = false;
+                if let Some(sdi12_service) = &mut self.sdi12_service {
+                    // if sdi12_service.is_awake() == false {
+                    //     sdi12_service.wake_up(board);
+                    // }
+
+                    if sdi12_service.is_awake(board) {
+                        defmt::println!("board awake!");
+                        match sdi12_service.take_message('0', board) {
+                            Ok(mode) => {
+                                match mode {
+                                    Sdi12Command::M => {
+                                    }
+
+                                    Sdi12Command::HA => {
+                                        let mut total_measurements_count = 0;
+
+                                        // for i in 0 .. self.sensor_drivers.len() {
+                                        //     if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                        //         let driver_measurements = driver.get_measured_parameter_count();
+                                        //         total_measurements_count = total_measurements_count + driver_measurements;
+                                        //     }
+                                        // }
+
+                                        total_measurements_count = 17;
+
+                                        let measurement_time = 5; // 5 seconds approximate for now
+                                        defmt::println!("total_measurements: {}", total_measurements_count);
+                                        sdi12_service.send_ha_ack(board, '0', measurement_time, total_measurements_count);
+                                        sdi12_service.set_total_measurements(total_measurements_count);
+                                        take_measurement = true;
+                                        sdi12_service.sleep(board); // this sensor doesn't have readings immediately available.
+                                        defmt::println!("SDI12: sleep");
+                                        // board.usb_serial_send(format_args!("SDI12: sleep\n"));
+                                    }
+
+                                    Sdi12Command::Mc(digit) => {
+                                        if digit == '0' {
+                                            let mut total_measurements_count = 0;
+
+                                            for i in 0 .. self.sensor_drivers.len() {
+                                                if let Some(ref mut driver) = self.sensor_drivers[i] {
+                                                    let driver_measurements = driver.get_measured_parameter_count();
+                                                    total_measurements_count = total_measurements_count + driver_measurements;
+                                                }
+                                            }
+
+
+                                            let measurement_time = 5; // 5 seconds approximate for now
+                                            defmt::println!("total_measurements: {}", total_measurements_count);
+                                            let n = if total_measurements_count > 9 {9_u8} else {total_measurements_count as u8};
+                                            sdi12_service.send_m_ack(board, '0', measurement_time, n);
+                                            sdi12_service.set_total_measurements(n as usize);
+                                            take_measurement = true;
+                                            sdi12_service.sleep(board); // this sensor doesn't have readings immediately available.
+                                            board.usb_serial_send(format_args!("SDI12: sleep\n"));
+                                        }
+                                        defmt::println!("Sent Ack to M");
+                                    }
+
+                                    Sdi12Command::D(digit) => {
+                                       
+                                            let mut data_send: [f64; MEASUREMENTS_IN_PAYLOAD as usize] = [f64::MAX; MEASUREMENTS_IN_PAYLOAD as usize];
+
+                                            let index = digit.to_digit(10);
+                                            if index.is_none() {
+                                                defmt::println!("parse error");
+                                                return;
+                                                //TODO: best way to handle this?
+                                            }
+                                            let index = index.unwrap() as usize;
+                                            defmt::println!("index {}", index);
+
+                                            let start = index * MEASUREMENTS_IN_PAYLOAD as usize;
+                                            let end = start + min(MEASUREMENTS_IN_PAYLOAD as usize, sdi12_service.get_total_measurements() - start);
+                                            for i in start..end {
+                                                data_send[i-start] = sdi12_service.get_data(i);
+                                            }
+                                            
+                                            defmt::println!("Data ready");
+                                            sdi12_service.send_data(board, '0', data_send, min(MEASUREMENTS_IN_PAYLOAD, (sdi12_service.get_total_measurements() - start) as u8));
+                                            defmt::println!("Sent data");
+                                            sdi12_service.sleep(board);
+                                            // if end == sdi12_service.get_total_measurements() {
+                                            //     sdi12_service.sleep(board);
+                                            //     board.usb_serial_send(format_args!("SDI12: sleep\n"));
+                                            // }
+                                    }
+                                }
+                            }
+                            Err(message) => {
+                                defmt::println!("Error: {}", message);
+                                // responses::send_command_response_error(board, message, "")
+                            }
+                        }
+                    }
+                    // else {
+                    //     defmt::println!("board sleeping");
+                    // }
+                }
+                else {
+                    defmt::panic!("sdi12 service not setup");
+                }
+
+                if take_measurement {
+                    board.usb_serial_send(format_args!("SDI12: taking measurement\n"));
+
+                    // self.measure_sensor_values(board);
+
+                    let sdi12_service =  self.sdi12_service.as_mut().unwrap();
+
+                    // let mut measurement_index = 0;
+                    // for i in 0 .. self.sensor_drivers.len() {
+                    //     if let Some(ref mut driver) = self.sensor_drivers[i] {
+                    //         for j in 0..driver.get_measured_parameter_count() {
+                    //             let value = match driver.get_measured_parameter_value(j) {
+                    //                 Ok(value) => value,
+                    //                 Err(_) => f64::MAX,
+                    //             };
+                    //             sdi12_service.fill_data(measurement_index, value);
+                    //             measurement_index = measurement_index + 1;
+                    //         }
+                    //     }
+                    // }
+                    for i in 0..17 {
+                        sdi12_service.fill_data(i, (i + 1) as f64 / 10.0);
+                    }
+
+                    board.usb_serial_send(format_args!("SDI12: measurement ready\n"));
+                }
             }
         }
     }
@@ -696,6 +840,7 @@ impl DataLogger {
                     board.write_log_file(format_args!(","));
                 }
 
+
                 for j in 0..driver.get_measured_parameter_count() {
                     match driver.get_measured_parameter_value(j) {
                         Ok(value) => {
@@ -767,6 +912,14 @@ impl DataLogger {
                         // switching into field mode should create a new file
                         self.write_column_headers_to_storage(board);
                         persist = true;
+                    }
+                    "sdi12" => {
+                        self.mode = DataLoggerMode::SDI12;
+                        self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
+                        sdi12_service::setup(board, 5);
+                        board.set_debug(false);
+                        persist = true;
+                        defmt::println!("In SDI12 mode!");
                     }
                     _ => {
                         self.mode = DataLoggerMode::Interactive;
@@ -1315,6 +1468,15 @@ impl DataLogger {
             }
         }
 
+        // if let Some(enable_sdi12) = &values.enable_sdi12 {
+        //     if self.settings.toggles.enable_sdi12() != *enable_sdi12 {
+        //        match self.set_up_modbus_rtu(*enable_sdi12) {
+        //             Ok(_) => {},
+        //             Err(error) => {return Err(error);}, 
+        //         }
+        //     }
+        // }
+
         let new_settings: DataloggerSettings = self.settings.with_values(values);
         let mut old_settings: DataloggerSettings = self.settings.clone();
         self.settings = new_settings;
@@ -1370,7 +1532,8 @@ impl DataLogger {
            "mode" : datalogger::modes::mode_text(&self.mode),
            "interactive_logging": self.settings.toggles.enable_interactive_logging(),
            "enable_lorawan_telemetry" : self.settings.toggles.enable_lorawan_telemetry(),
-           "enable_modbus_rtu" : self.settings.toggles.enable_modbus_rtu()
+           "enable_modbus_rtu" : self.settings.toggles.enable_modbus_rtu(),
+           "enable_sdi12" : self.settings.toggles.enable_sdi12(),
         })
     }
 

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -557,6 +557,8 @@ impl DataLogger {
                     }
 
                     board.usb_serial_send(format_args!("SDI12: measurement ready\n"));
+                    self.write_last_measurement_to_serial(board); // watch mode stuff
+
                 }
             }
         }

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -547,7 +547,7 @@ impl DataLogger {
                             for j in 0..driver.get_measured_parameter_count() {
                                 let value = match driver.get_measured_parameter_value(j) {
                                     Ok(value) => value,
-                                    Err(_) => f64::MAX,
+                                    Err(_) => -99.0, // can't send max b/c we only use 4 chars.
                                 };
                                 sdi12_service.fill_data(measurement_index, value);
                                 // defmt::println!("data[{}] = {}", measurement_index, value);
@@ -773,7 +773,7 @@ impl DataLogger {
                 for j in 0..driver.get_measured_parameter_count() {
                     match driver.get_measured_parameter_value(j) {
                         Ok(value) => {
-                            let value = (value * 1000f64) as u32;
+                            let value = (value * 1000f64) as i32;
                             match util::format_decimal(value) {
                                 Ok((buf,size)) => {
                                     let decimal = unsafe { core::str::from_utf8_unchecked(&buf[..size]) };
@@ -849,7 +849,7 @@ impl DataLogger {
                 for j in 0..driver.get_measured_parameter_count() {
                     match driver.get_measured_parameter_value(j) {
                         Ok(value) => {
-                            let value = (value * 1000f64) as u32;
+                            let value = (value * 1000f64) as i32;
                             match util::format_decimal(value) {
                                 Ok((buf,size)) => {
                                     let decimal = unsafe { core::str::from_utf8_unchecked(&buf[..size]) };

--- a/src/datalogger/src/lib.rs
+++ b/src/datalogger/src/lib.rs
@@ -881,57 +881,71 @@ impl DataLogger {
     }
 
     pub fn set_mode(&mut self, board: &mut impl RRIVBoard, mode: Value) -> bool {
-        let mut persist = false;
-        match mode {
+
+        let mode_value =  match mode {
             Value::String(mode) => {
-                let mode = mode.as_str();
-                // TODO: perhaps watch should be separate from mode, so you can watch any mode
-                // TODO: and rrivctl can still accept commands when in watch mode
-                match mode {
-                    "watch" => {
-                        self.write_column_headers_to_serial(board);
-                        self.serial_tx_mode = DataLoggerSerialTxMode::Watch;
-                        board.set_debug(false);
-                        self.set_telemeter_watch(true);
-                    }
-                    "watch-debug" => {
-                        self.write_column_headers_to_serial(board);
-                        self.serial_tx_mode = DataLoggerSerialTxMode::Watch;
-                        board.set_debug(true);
-                        self.set_telemeter_watch(true);
-                    }
-                    "quiet" => {
-                        self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
-                        board.set_debug(false);
-                        self.set_telemeter_watch(false);
-                    }
-                    "field" => {
-                        self.mode = DataLoggerMode::Field;
-                        // switching into field mode should create a new file
-                        self.write_column_headers_to_storage(board);
-                        persist = true;
-                    }
-                    "sdi12" => {
-                        self.mode = DataLoggerMode::SDI12;
-                        self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
-                        sdi12_service::setup(board, 5);
-                        board.set_debug(false);
-                        persist = true;
-                        defmt::println!("In SDI12 mode!");
-                    }
-                    _ => {
-                        self.mode = DataLoggerMode::Interactive;
-                        self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
-                        board.set_debug(false);
-                        self.set_telemeter_watch(false);
-                        persist = true;
-                    }
-                }
+                mode
             }
-            _ => {}
+            _ => { return false; }
+        };
+        let mode = mode_value.as_str();
+
+        // TODO: these are not true modes, need to be factored elsewhere
+        let mut done = true;
+        match mode {
+            "watch" => {
+                self.write_column_headers_to_serial(board);
+                self.serial_tx_mode = DataLoggerSerialTxMode::Watch;
+                board.set_debug(false);
+                self.set_telemeter_watch(true);
+            }
+            "watch-debug" => {
+                self.write_column_headers_to_serial(board);
+                self.serial_tx_mode = DataLoggerSerialTxMode::Watch;
+                board.set_debug(true);
+                self.set_telemeter_watch(true);
+            }
+            "quiet" => {
+                self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
+                board.set_debug(false);
+                self.set_telemeter_watch(false);
+            }
+            _ => {
+                done = false;
+            }
         }
+        if done { 
+            return false;
+        }
+
+        if self.settings.toggles.lock_mode() {
+            // persistant mode is locked, do nothing.
+            return false;
+        }
+        
+        match mode {
+            "field" => {
+                self.mode = DataLoggerMode::Field;
+                // switching into field mode should create a new file
+                self.write_column_headers_to_storage(board);
+            }
+            "sdi12" => {
+                self.mode = DataLoggerMode::SDI12;
+                self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
+                sdi12_service::setup(board, 5);
+                board.set_debug(false);
+                defmt::println!("In SDI12 mode!");
+            }
+            _ => {
+                self.mode = DataLoggerMode::Interactive;
+                self.serial_tx_mode = DataLoggerSerialTxMode::Quiet;
+                board.set_debug(false);
+                self.set_telemeter_watch(false);
+            }
+        };
         self.settings.mode = self.mode.to_u8();
-        return persist;
+        return true;
+
     }
 
     fn set_telemeter_watch(&mut self, watch: bool) {
@@ -1528,6 +1542,7 @@ impl DataLogger {
            "delay_between_bursts" : self.settings.delay_between_bursts,
            "bursts_per_measurement_cycle" : self.settings.bursts_per_measurement_cycle,
            "mode" : datalogger::modes::mode_text(&self.mode),
+           "lock_mode" : self.settings.toggles.lock_mode(),
            "interactive_logging": self.settings.toggles.enable_interactive_logging(),
            "enable_lorawan_telemetry" : self.settings.toggles.enable_lorawan_telemetry(),
            "enable_modbus_rtu" : self.settings.toggles.enable_modbus_rtu(),

--- a/src/datalogger/src/registry.rs
+++ b/src/datalogger/src/registry.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use crate::drivers::{ types::{SensorDriver, SensorDriverGeneralConfiguration, SENSOR_SETTINGS_PARTITION_SIZE}};
 
 
-const SENSOR_NAMES: [&str; 14] = [
+const SENSOR_NAMES: [&str; 15] = [
     "no_match",
     "generic_analog",
     "atlas_ec",
@@ -16,7 +16,8 @@ const SENSOR_NAMES: [&str; 14] = [
     "ring_w_mux",
     "ring_temp_sim",
     "groundwater_rtu",
-    "mhz9041a"
+    "mhz9041a",
+    "gndwater_sdi12",
 ];
 
 pub fn sensor_type_id_from_name(name: &str) -> Result<u16, ()> {
@@ -134,6 +135,10 @@ pub fn get_registry() -> [DriverCreateFunctions; 256] {
     driver_create_functions[13] = Some(driver_create_functions!(
         crate::drivers::mhz9041a::MHZ9041ADriver,
         crate::drivers::mhz9041a::MHZ9041ADriverSpecialConfiguration
+    ));
+    driver_create_functions[14] = Some(driver_create_functions!(
+        crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12,
+        crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12SpecialConfiguration
     ));
 
     driver_create_functions

--- a/src/datalogger/src/registry.rs
+++ b/src/datalogger/src/registry.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use crate::drivers::{ types::{SensorDriver, SensorDriverGeneralConfiguration, SENSOR_SETTINGS_PARTITION_SIZE}};
 
 
-const SENSOR_NAMES: [&str; 15] = [
+const SENSOR_NAMES: [&str; 16] = [
     "no_match",
     "generic_analog",
     "atlas_ec",
@@ -18,6 +18,7 @@ const SENSOR_NAMES: [&str; 15] = [
     "groundwater_rtu",
     "mhz9041a",
     "gndwater_sdi12",
+    "ring_w_mux_sim",
 ];
 
 pub fn sensor_type_id_from_name(name: &str) -> Result<u16, ()> {
@@ -140,7 +141,10 @@ pub fn get_registry() -> [DriverCreateFunctions; 256] {
         crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12,
         crate::drivers::groundwater_flow_sdi12::GroundwaterFlowSDI12SpecialConfiguration
     ));
-
+    driver_create_functions[15] = Some(driver_create_functions!(
+        crate::drivers::ring_w_mux_sim::RingMuxTemperatureDriver,
+        crate::drivers::ring_w_mux_sim::RingMuxTemperatureDriverSpecialConfiguration
+    ));
     driver_create_functions
 }
 

--- a/src/datalogger/src/services/mod.rs
+++ b/src/datalogger/src/services/mod.rs
@@ -3,3 +3,4 @@
 pub mod command_service;
 pub mod usart_service;
 pub mod modbus_service;
+pub mod sdi12_service;

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -191,6 +191,9 @@ impl<'a> Sdi12RxProcessor {
             }
             else if board.get_current_time().wrapping_sub(now) > 100000 {
                 // timeout after 100 milliseconds
+                let my_board = Sdi12Board::new(self.gpio, board);
+                let mut sdi12 = SDI12::new(my_board);
+                sdi12.sleep();
                 defmt::println!("SDI12: command reception timeout");
                 return Err("Command reception timeout");
             }

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -1,0 +1,736 @@
+use rriv_board::{RRIVBoard, gpio};
+use sdi12::*;
+use core::fmt::{self, Write};
+
+pub const MEASUREMENTS_IN_PAYLOAD: u8 = 4;
+
+pub enum Sdi12Command {
+    M,
+    Mc(char),
+    D(char),
+    HA,
+}
+
+#[allow(non_camel_case_types, unused)]
+pub struct SDI12_MResponse {
+    pub ttt: u32,
+    pub n: u8
+}
+
+#[allow(non_camel_case_types, unused)]
+pub struct SDI12_HAResponse {
+    pub ttt: u32,
+    pub nnn: u32
+}
+
+#[allow(non_camel_case_types, unused)]
+pub struct SDI12_Dresponse {
+    pub address: char,
+    pub data: [f32; MEASUREMENTS_IN_PAYLOAD as usize],
+    pub count: u8,
+}
+
+struct CharBuffer<'a> {
+    buffer: &'a mut [char],
+    cursor: usize,
+}
+
+impl<'a> Write for CharBuffer<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            if self.cursor < self.buffer.len() {
+                self.buffer[self.cursor] = c;
+                self.cursor += 1;
+            } else {
+                // Return an error if we run out of space in the array
+                return Err(fmt::Error); 
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct Sdi12Board <'a> {
+    gpio: u8,
+    board: &'a mut dyn RRIVBoard
+}
+
+impl<'a> Sdi12Board<'a> {
+    pub fn new(gpio: u8, board: &'a mut dyn RRIVBoard) -> Self {
+        Sdi12Board {
+            gpio,
+            board
+        }
+    }
+}
+
+impl<'a> BoardForSDI12 for Sdi12Board<'a> {
+    fn write(&mut self, value: bool) {
+        self.board.write_gpio_pin(self.gpio, value);
+    }
+
+    fn read(&mut self) -> bool {
+        let result = self.board.read_gpio_pin(self.gpio);
+        let value = match result {
+            Ok(value) => value,
+            Err(_) => false
+        };
+        value
+    }
+
+    fn delay_us(&mut self, us: u16) {
+        self.board.delay_us(us);
+        self.board.run_loop_iteration(); // TODO: feed the watchdog, need a dedicated call for this though.
+    }
+
+    fn pin_mode(&mut self, mode: gpio::GpioMode) {
+        self.board.set_gpio_pin_mode(self.gpio, mode);
+    }
+
+    fn millis(&mut self) -> u32 {
+        self.board.millis()
+    }
+
+    fn enable_interrupt(&mut self) {
+        self.board.enable_interrupt();
+    }
+
+    fn disable_interrupt(&mut self) {
+        self.board.disable_interrupt();
+    }
+
+    fn get_current_time(&self) -> u32 {
+        self.board.get_current_time()
+    }
+
+}
+
+
+pub fn setup(board: &mut dyn RRIVBoard, gpio: u8) {
+    rriv_board::configure_gpio_interrupt_function(sdi12::probe_interrupt_handler);
+    let my_board = Sdi12Board::new(gpio, board);
+    let mut sdi12 = SDI12::new(my_board);
+    sdi12.sleep();
+}
+
+pub struct Sdi12RxProcessor {
+    gpio: u8,
+    awake: bool,
+    data: [f64; 36],
+    total_measurements: usize,
+}
+
+impl<'a> Sdi12RxProcessor {
+    pub fn new(gpio: u8) -> Sdi12RxProcessor {
+        Sdi12RxProcessor {
+            gpio: gpio,
+            awake: false,
+            data: [-5.0; 36],
+            total_measurements: 0,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn wake_up(&mut self, board: &mut dyn RRIVBoard) {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        self.awake = sdi12.receive_break();
+        if self.awake {
+            board.usb_serial_send(format_args!("SDI12: received break\n"));
+        }
+    }
+
+    pub fn set_total_measurements(&mut self, n: usize) {
+        self.total_measurements = n;
+    }
+
+    pub fn fill_data(&mut self, index: usize, value: f64) {
+        self.data[index] = value;
+    }
+
+    pub fn get_data(&mut self, index: usize) -> f64 {
+        self.data[index]
+    }
+
+    pub fn get_total_measurements(&self) -> usize {
+        self.total_measurements
+    }
+
+    pub fn is_awake(&mut self, board: &mut dyn RRIVBoard) -> bool {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        self.awake = sdi12.awake();
+        self.awake
+    }
+
+    pub fn sleep(&mut self, board: &mut dyn RRIVBoard) {
+        defmt::println!("board asleep");
+        self.awake = false;
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        sdi12.sleep();
+    }
+
+    pub fn take_message(&mut self, address: char, board: &mut dyn RRIVBoard) -> Result<Sdi12Command, &str> {
+        let mut buffer : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        let mut i = 0;
+        let mut now = board.get_current_time();
+        loop {
+            let my_board = Sdi12Board::new(self.gpio, board);
+            let mut sdi12 = SDI12::new(my_board);
+            if sdi12.available() > 0 {
+                if let Some(c) = sdi12.read() {
+                    buffer[i] = c;
+                    i += 1;
+                    if c == '!' || i >= SDI12_COMMAND_SIZE {
+                        sdi12.clear_buffer();
+                        break;
+                    }
+                }
+                now = board.get_current_time(); // reset timeout timer on every received character
+            }
+            else if board.get_current_time().wrapping_sub(now) > 100000 {
+                // timeout after 100 milliseconds
+                defmt::println!("SDI12: command reception timeout");
+                return Err("Command reception timeout");
+            }
+        }
+
+        if buffer[0] != address {
+            self.sleep(board);
+            board.usb_serial_send(format_args!("SDI12: sleep\n"));
+            defmt::println!("{} != {}", buffer[0], address);
+            return Err("Address not matching");
+        }
+        
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}\n", buffer[0], buffer[1], buffer[2]));
+
+        let mode = match (buffer[1], buffer[2]) {
+            ('M', '!') => Sdi12Command::M,
+            ('M', d @ '0'..='9') => Sdi12Command::Mc(d),
+            ('D', d @ '0'..='9') => Sdi12Command::D(d),
+            ('H', 'A') => Sdi12Command::HA,
+            _ => return Err("Invalid Command"),
+        };
+
+        Ok(mode)
+    }
+
+    pub fn send_m_ack(&mut self, board: &mut dyn RRIVBoard, address: char, ttt: u32, n: u8) {
+        let mut resp_buffer: [char; SDI12_BUFFER_SIZE] = ['0'; SDI12_BUFFER_SIZE];
+        resp_buffer[0] = address;
+
+        resp_buffer[1] = (b'0' + ((ttt / 100) % 10) as u8) as char; // Hundreds
+        resp_buffer[2] = (b'0' + ((ttt / 10) % 10) as u8) as char;  // Tens
+        resp_buffer[3] = (b'0' + (ttt % 10) as u8) as char;         // Ones
+
+        resp_buffer[4] = (b'0' + n) as char;            
+
+        resp_buffer[5] = '\r';
+        resp_buffer[6] = '\n';
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        sdi12.send_response(resp_buffer);
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}\n", resp_buffer[0], resp_buffer[1], resp_buffer[2], resp_buffer[3], resp_buffer[4])); // TODO: if self.watch
+    }
+
+    pub fn send_ha_ack(&mut self, board: &mut dyn RRIVBoard, address: char, ttt: u32, nnn: usize) {
+        let mut resp_buffer: [char; SDI12_BUFFER_SIZE] = ['0'; SDI12_BUFFER_SIZE];
+        resp_buffer[0] = address;
+
+        resp_buffer[1] = (b'0' + ((ttt / 100) % 10) as u8) as char; // Hundreds
+        resp_buffer[2] = (b'0' + ((ttt / 10) % 10) as u8) as char;  // Tens
+        resp_buffer[3] = (b'0' + (ttt % 10) as u8) as char;         // Ones
+
+        resp_buffer[4] = (b'0' + ((nnn / 100) % 10) as u8) as char; // Hundreds
+        resp_buffer[5] = (b'0' + ((nnn / 10) % 10) as u8) as char;  // Tens
+        resp_buffer[6] = (b'0' + (nnn % 10) as u8) as char;         // Ones          
+
+        resp_buffer[7] = '\r';
+        resp_buffer[8] = '\n';
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        sdi12.send_response(resp_buffer);
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}{}{}\n", resp_buffer[0], resp_buffer[1], resp_buffer[2], resp_buffer[3], resp_buffer[4], resp_buffer[5], resp_buffer[6])); // TODO: if self.watch
+    }
+
+    pub fn send_data(&mut self, board: &mut dyn RRIVBoard, address: char, data: [f64;MEASUREMENTS_IN_PAYLOAD as usize], n: u8) {
+        let mut resp_buffer: [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
+
+        let mut writer = CharBuffer {
+            buffer: &mut resp_buffer,
+            cursor: 0,
+        };
+
+        let _ = write!(writer, "{}", address);
+
+        let mut i = 0;
+        for &value in &data {
+            let _ = write!(writer, "{:+.2}", value);
+            i += 1;
+            if i == n {
+                break;
+            }
+        }
+
+        // End with <CR><LF>
+        let _ = write!(writer, "\r\n");
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        sdi12.send_response(resp_buffer);
+        // board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\n", 
+        //     resp_buffer[0], 
+        //     resp_buffer[1], 
+        //     resp_buffer[2], 
+        //     resp_buffer[3], 
+        //     resp_buffer[4], 
+        //     resp_buffer[5], 
+        //     resp_buffer[6], 
+        //     resp_buffer[7], 
+        //     resp_buffer[8],
+        //     resp_buffer[9],
+        //     resp_buffer[10], 
+        //     resp_buffer[11], 
+        //     resp_buffer[12], 
+        //     resp_buffer[13], 
+        //     resp_buffer[14], 
+        //     resp_buffer[15], 
+        //     resp_buffer[16], 
+        //     resp_buffer[17], 
+        //     resp_buffer[18],
+        //     resp_buffer[19],
+        //     resp_buffer[20], 
+        //     resp_buffer[21], 
+        //     resp_buffer[22], 
+        //     resp_buffer[23], 
+        //     resp_buffer[24], 
+        //     resp_buffer[25], 
+        //     resp_buffer[26], 
+        //     resp_buffer[27], 
+        //     resp_buffer[28],
+        //     resp_buffer[29]
+        // )); // TODO: if self.watch
+        defmt::println!("SDI12: sent {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\n", 
+            resp_buffer[0], 
+            resp_buffer[1], 
+            resp_buffer[2], 
+            resp_buffer[3], 
+            resp_buffer[4], 
+            resp_buffer[5], 
+            resp_buffer[6], 
+            resp_buffer[7], 
+            resp_buffer[8],
+            resp_buffer[9],
+            resp_buffer[10], 
+            resp_buffer[11], 
+            resp_buffer[12], 
+            resp_buffer[13], 
+            resp_buffer[14], 
+            resp_buffer[15], 
+            resp_buffer[16], 
+            resp_buffer[17], 
+            resp_buffer[18],
+            resp_buffer[19],
+            resp_buffer[20], 
+            resp_buffer[21], 
+            resp_buffer[22], 
+            resp_buffer[23], 
+            resp_buffer[24], 
+            resp_buffer[25], 
+            resp_buffer[26], 
+            resp_buffer[27], 
+            resp_buffer[28],
+            resp_buffer[29]
+        ); // TODO: if self.watch
+
+    }
+}
+
+
+
+pub struct Sdi12TxProcessor {
+    gpio: u8,
+    address: char
+}
+
+impl<'a> Sdi12TxProcessor {
+    pub fn new(gpio: u8, address: char) -> Sdi12TxProcessor {
+        Sdi12TxProcessor {
+            gpio: gpio,
+            address: address,
+        }
+    }
+
+    pub fn setup(&mut self) {
+        rriv_board::configure_gpio_interrupt_function(sdi12::datalogger_interrupt_handler);
+    }
+
+    pub fn send_break(&mut self, board: &mut dyn RRIVBoard) {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        defmt::println!("Sent break");
+        sdi12.send_break();
+    }
+
+    #[allow(unused)]
+    pub fn send_command(&mut self, board: &mut dyn RRIVBoard, cmd: Sdi12Command) {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = self.address;
+        match cmd {
+            Sdi12Command::HA => {
+                command[1] = 'H';
+                command[2] = 'A';
+                command[3] = '!';
+            }
+            Sdi12Command::M => {
+                command[1] = 'M';
+                command[2] = '!';
+            }
+            Sdi12Command::Mc(id) => {
+                command[1] = 'M';
+                command[2] = id;
+                command[3] = '!';
+            }
+            Sdi12Command::D(id) => {
+                command[1] = 'D';
+                command[2] = id;
+                command[3] = '!';
+            }
+            _ => {
+                defmt::println!("Wrong command");
+                return;
+            }
+        }
+        sdi12.send_command(command);
+        defmt::println!("SDI12: sent {}{}{}{}", command[0], command[1], command[2], command[3]);
+        // board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}\n", command[0], command[1], command[2], command[3])); // TODO: if self.watch
+
+    }
+
+    pub fn read_response(&mut self, board: &mut dyn RRIVBoard) -> Result<[char; SDI12_BUFFER_SIZE], &'static str> {
+        let mut now = board.get_current_time();
+        let mut i = 0;
+        let mut response : [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
+        loop {
+            let my_board = Sdi12Board::new(self.gpio, board);
+            let mut sdi12 = SDI12::new(my_board);
+            if sdi12.available() > 0 {
+                if let Some(c) = sdi12.read() {
+                    response[i] = c;
+                    i += 1;
+                    // defmt::println!("SDI12: read char {}", c);
+                    if c == '\n' || i >= SDI12_BUFFER_SIZE {
+                        sdi12.clear_buffer();
+                        break;
+                    }
+                }
+                now = board.get_current_time(); // reset timeout timer on every received character
+            }
+            else if board.get_current_time().wrapping_sub(now) > 150000 {
+                // timeout after 15 milliseconds
+                defmt::println!("SDI12: response timeout");
+                let my_board = Sdi12Board::new(self.gpio, board);
+                let mut sdi12 = SDI12::new(my_board);
+                sdi12.clear_buffer();
+                return Err("Response timeout");
+            }
+        }
+        defmt::println!("SDI12: received {}{}{}{}{}\n", response[0], response[1], response[2], response[3], response[4]);
+        // board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}\n", response[0], response[1], response[2], response[3], response[4])); // TODO: if self.watch
+        Ok(response)
+    }
+
+    #[allow(unused)]
+    pub fn parse_ha_command(&mut self, response: [char; SDI12_BUFFER_SIZE]) -> Option<SDI12_HAResponse> {
+        let address_r = response[0];
+        if address_r != self.address {
+            // invalid response
+            return None;
+        }
+
+        let ttt_str = &response[1..4];
+        let mut ttt: u32 = 0; // Or u32, usize, etc.
+        for &c in ttt_str {
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                ttt = (ttt * 10) + d as u32;
+            }
+        }
+
+        let nnn_str = &response[4..7];
+        let mut nnn = 0;
+        for &c in nnn_str {
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                nnn = (nnn * 10) + d as u32;
+            }
+        }
+
+        // self.sdi12_board.delay_us(SDI12_GAP);
+        
+        let res = SDI12_HAResponse {
+                                    ttt: ttt,
+                                    nnn: nnn
+                                };
+        Some(res)
+    }
+
+    #[allow(unused)]
+    pub fn parse_d_command(&mut self, board: &mut dyn RRIVBoard, response: [char; SDI12_BUFFER_SIZE]) -> Option<SDI12_Dresponse> {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut resp : SDI12_Dresponse = SDI12_Dresponse {
+            address: '\0',
+            data: [0.0; MEASUREMENTS_IN_PAYLOAD as usize],
+            count: 0,
+        };
+
+        // parse the response
+        // format: <address><data><CR><LF>
+        let address_r = response[0];
+        if address_r != self.address {
+            // invalid response
+            return None;
+        }
+        resp.address = address_r;
+        let response = &response[1..SDI12_BUFFER_SIZE];
+        let (parsed_data, count) = sdi12.parse_data(response);
+
+        resp.count = count;
+        for i in 0..MEASUREMENTS_IN_PAYLOAD as usize {
+            resp.data[i] = parsed_data[i];
+        }
+        
+        // board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\n", 
+        //     response[0], 
+        //     response[1], 
+        //     response[2], 
+        //     response[3], 
+        //     response[4], 
+        //     response[5], 
+        //     response[6], 
+        //     response[7], 
+        //     response[8],
+        //     response[9],
+        //     response[10], 
+        //     response[11], 
+        //     response[12], 
+        //     response[13], 
+        //     response[14], 
+        //     response[15], 
+        //     response[16], 
+        //     response[17], 
+        //     response[18],
+        //     response[19],
+        //     response[20], 
+        //     response[21], 
+        //     response[22], 
+        //     response[23], 
+        //     response[24], 
+        //     response[25], 
+        //     response[26], 
+        //     response[27], 
+        //     response[28],
+        //     response[29]
+        // )); // TODO: if self.watch
+
+        Some(resp)
+    }
+
+    #[allow(unused)]
+    pub fn send_m_command(&mut self, board: &mut dyn RRIVBoard, id: char) -> Option<SDI12_MResponse> {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = self.address;
+        command[1] = 'M';
+        if id == '\0' {
+            command[2] = '!';
+        }
+        else {
+            command[2] = id;
+            command[3] = '!';
+        }
+        sdi12.send_command(command);
+        defmt::println!("Sent 0M0!");
+
+        let response = sdi12.read_response();
+
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}\n", command[0], command[1], command[2], command[3])); // TODO: if self.watch
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}\n", response[0], response[1], response[2], response[3], response[4])); // TODO: if self.watch
+
+        // parse the response
+        // format: <address>tttn<CR><LF>
+        let address_r = response[0];
+        if address_r != self.address {
+            // invalid response
+            return None;
+        }
+
+        let ttt = &response[1..4];
+        // convert ttt from ASCII to integer
+        let mut result: u32 = 0; // Or u32, usize, etc.
+
+        for &c in ttt {
+            // to_digit(10) converts the char to a number from 0-9
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                result = (result * 10) + d as u32;
+            }
+        }
+
+        let n : u8 = response[4].to_digit(10).unwrap_or(0) as u8; // convert ASCII to integer
+
+        // self.sdi12_board.delay_us(SDI12_GAP);
+        
+        let res = SDI12_MResponse {
+                                    ttt: result,
+                                    n: n
+                                };
+        Some(res)
+    }
+
+    #[allow(unused)]
+    pub fn send_ha_command(&mut self, board: &mut dyn RRIVBoard) -> Option<SDI12_HAResponse> {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = self.address;
+        command[1] = 'H';
+        command[2] = 'A';
+        command[3] = '!';
+        sdi12.send_command(command);
+        defmt::println!("Sent 0HA!");
+
+        let response = sdi12.read_response();
+
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}\n", command[0], command[1], command[2], command[3])); // TODO: if self.watch
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}\n", response[0], response[1], response[2], response[3], response[4])); // TODO: if self.watch
+
+        // parse the response
+        // format: <address>tttn<CR><LF>
+        let address_r = response[0];
+        if address_r != self.address {
+            // invalid response
+            return None;
+        }
+
+        let ttt_str = &response[1..4];
+        let mut ttt: u32 = 0; // Or u32, usize, etc.
+        for &c in ttt_str {
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                ttt = (ttt * 10) + d as u32;
+            }
+        }
+
+        let nnn_str = &response[4..7];
+        let mut nnn = 0;
+        for &c in nnn_str {
+            let digit = c.to_digit(10);
+            if let Some(d) = digit {
+                nnn = (nnn * 10) + d as u32;
+            }
+        }
+
+        // self.sdi12_board.delay_us(SDI12_GAP);
+        
+        let res = SDI12_HAResponse {
+                                    ttt: ttt,
+                                    nnn: nnn
+                                };
+        Some(res)
+    }
+    
+    #[allow(unused)]
+    pub fn send_d_command(&mut self, board: &mut dyn RRIVBoard, id: u8) -> Option<SDI12_Dresponse> {
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        let mut command : [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        command[0] = self.address;
+        command[1] = 'D';
+        command[2] = (id + b'0') as char;
+        command[3] = '!';
+        let mut resp : SDI12_Dresponse = SDI12_Dresponse {
+            address: '\0',
+            data: [0.0; MEASUREMENTS_IN_PAYLOAD as usize],
+            count: 0,
+        };
+        
+        sdi12.send_command(command);
+        let response = sdi12.read_response();
+
+        board.usb_serial_send(format_args!("SDI12: sent {}{}{}{}{}\n", command[0], command[1], command[2], command[3], command[4])); // TODO: if self.watch
+
+
+        let my_board = Sdi12Board::new(self.gpio, board);
+        let mut sdi12 = SDI12::new(my_board);
+        
+        // parse the response
+        // format: <address><data><CR><LF>
+        let address_r = response[0];
+        if address_r != self.address {
+            // invalid response
+            return None;
+        }
+        resp.address = address_r;
+        let response = &response[1..SDI12_BUFFER_SIZE];
+        let (parsed_data, count) = sdi12.parse_data(response);
+
+        resp.count = count;
+        for i in 0..MEASUREMENTS_IN_PAYLOAD as usize {
+            resp.data[i] = parsed_data[i];
+        }
+        
+        // if resp.count == num_data {
+        //     resp.terminate = true;
+        // }
+        // resp.last_d_ind = id;
+
+        board.usb_serial_send(format_args!("SDI12: received {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\n", 
+            response[0], 
+            response[1], 
+            response[2], 
+            response[3], 
+            response[4], 
+            response[5], 
+            response[6], 
+            response[7], 
+            response[8],
+            response[9],
+            response[10], 
+            response[11], 
+            response[12], 
+            response[13], 
+            response[14], 
+            response[15], 
+            response[16], 
+            response[17], 
+            response[18],
+            response[19],
+            response[20], 
+            response[21], 
+            response[22], 
+            response[23], 
+            response[24], 
+            response[25], 
+            response[26], 
+            response[27], 
+            response[28],
+            response[29]
+        )); // TODO: if self.watch
+
+        Some(resp)
+    }
+}
+
+
+
+

--- a/src/datalogger/src/services/sdi12_service.rs
+++ b/src/datalogger/src/services/sdi12_service.rs
@@ -203,7 +203,8 @@ impl<'a> Sdi12RxProcessor {
             return Err("Address not matching");
         }
         
-        board.usb_serial_send(format_args!("SDI12: received {}{}{}\n", buffer[0], buffer[1], buffer[2]));
+        // board.usb_serial_send(format_args!("SDI12: received {}{}{}\n", buffer[0], buffer[1], buffer[2]));
+        defmt::println!("SDI12: received {}{}{}", buffer[0], buffer[1], buffer[2]);
 
         let mode = match (buffer[1], buffer[2]) {
             ('M', '!') => Sdi12Command::M,

--- a/src/datalogger/src/telemetry/telemeters/modbus.rs
+++ b/src/datalogger/src/telemetry/telemeters/modbus.rs
@@ -87,7 +87,7 @@ fn transmit(board: &mut dyn RRIVBoard, payload: &[u8]){
         Ok(length) => {
             let message: &[u8] = &adu_buffer[0..length];
             for byte in message {
-                defmt::println!("tx byte: {:X}", byte);
+                // defmt::println!("tx byte: {:X}", byte);
             }
             transmit(board, message);
         },

--- a/src/datalogger/src/telemetry/telemeters/modbus.rs
+++ b/src/datalogger/src/telemetry/telemeters/modbus.rs
@@ -15,18 +15,22 @@ pub struct ModBusRTU();
 
 impl Telemeter for ModBusRTU {
 
+    #[allow(unused_variables)]
     fn transmit(&mut self, board: &mut dyn RRIVBoard, values: &[i16] ) {
         send_input_registers_response(board, values);
     }
     
+    #[allow(unused_variables)]
     fn run_loop_iteration(&mut self, board: &mut dyn RRIVBoard) {
         // nothing to do here yet
     }
     
+    #[allow(unused_variables)]
     fn ready_to_transmit(&mut self, board: &mut dyn RRIVBoard) -> bool {
         return true;
     }
-    
+
+    #[allow(unused_variables)]
     fn process_events(&mut self, board: &mut dyn RRIVBoard) {
         // not handled yet
     }
@@ -86,9 +90,9 @@ fn transmit(board: &mut dyn RRIVBoard, payload: &[u8]){
     match modbus_core::rtu::server::encode_response(adu, &mut adu_buffer) {
         Ok(length) => {
             let message: &[u8] = &adu_buffer[0..length];
-            for byte in message {
-                // defmt::println!("tx byte: {:X}", byte);
-            }
+            // for byte in message {
+            //     defmt::println!("tx byte: {:X}", byte);
+            // }
             transmit(board, message);
         },
         Err(_) => {

--- a/src/sdi12/Cargo.toml
+++ b/src/sdi12/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sdi-12"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+format_no_std = "1.2.0"
+rtt-target = { version = "0.6.1", features =  ["defmt"] }
+defmt = "1.0.1"
+

--- a/src/sdi12/Cargo.toml
+++ b/src/sdi12/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sdi-12"
+name = "sdi12"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,4 +7,5 @@ edition = "2021"
 format_no_std = "1.2.0"
 rtt-target = { version = "0.6.1", features =  ["defmt"] }
 defmt = "1.0.1"
+rriv_board = { path = "../../board/rriv_board" } 
 

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -1,0 +1,16 @@
+
+
+
+pub trait digital_pin {
+    pub fn write(value);
+    pub fn read() -> bool;
+}
+
+pub trait delay_us {
+    pub fn delay(ms: u32);
+}
+
+
+pub fn send_command(&str, &mut impl digital_pin, &mut impl delay_us) -> [u8;100] {
+    // sdi-12 implementation
+}

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -545,6 +545,12 @@ pub fn datalogger_interrupt_handler(now: u32, gpio_state: bool) {
             rx_mask <<= 1;   // for the current bit which is HIGH is stored as 0
         }
         else {
+            if bits_to_process == 0 {
+                // this is an error condition, since the next step will crash
+                defmt::println!("Invalid bit state, waiting for start bit again. to process: {}, passed: {}", bits_to_process, bits_passed);
+                unsafe{ RX_STATE = WAITING_FOR_START_BIT};
+                return;
+            }
             rx_mask <<= bits_to_process - 1;   // if the bit is LOW, just move the mask
             rx_value |= rx_mask;  // store the LOW bit as 1
         }
@@ -651,6 +657,12 @@ pub fn probe_interrupt_handler(now: u32, gpio_state: bool) {
                 rx_mask <<= 1;   // for the current bit which is HIGH is stored as 0
             }
             else {
+                if bits_to_process == 0 {
+                    // this is an error condition, since the next step will crash
+                defmt::println!("Invalid bit state, waiting for start bit again. to process: {}, passed: {}", bits_to_process, bits_passed);
+                    unsafe{ RX_STATE = WAITING_FOR_BREAK };
+                    return;
+                }
                 rx_mask <<= bits_to_process - 1;   // if the bit is LOW, just move the mask
                 rx_value |= rx_mask;  // store the LOW bit as 1
             }

--- a/src/sdi12/src/lib.rs
+++ b/src/sdi12/src/lib.rs
@@ -1,16 +1,687 @@
+#![no_std]
 
+use rriv_board::gpio;
 
+// SDI-12 Timing Constants (in microseconds)
+const SDI12_TIMING_TOLERANCE: u16 = 400;
+const SDI12_BREAK_DURATION_US: u16 = 12100;
+const SDI12_MARK_DURATION_US: u16 = 8400;
+const SDI12_TICKS_PER_BIT: u16 = 833; // 1 bit duration at 1200 baud
+// const SDI12_TIMEOUT : u32 = 100; // timeout for reading response in milliseconds
+const SDI12_GAP: u16 = 5000;
+pub const SDI12_BUFFER_SIZE: usize = 100; // size of the buffer for reading responses
+pub const SDI12_COMMAND_SIZE: usize = 10;
 
-pub trait digital_pin {
-    pub fn write(value);
-    pub fn read() -> bool;
+// RX BUFFER DATA
+const WAITING_FOR_START_BIT: u8 = 255;
+const WAITING_FOR_BREAK: u8 = 254;
+const WAITING_FOR_MARK: u8 = 253;
+const WAITING_FOR_START_AFTER_BREAK: u8 = 252;
+
+static mut LAST_TICK: u32 = 0;
+static mut RX_STATE: u8 = WAITING_FOR_START_BIT;      // 255 means idle state, 0-7 means receiving bits for a byte, 8 means waiting for stop bit
+static mut RX_VALUE: u8 = 0x00;
+static mut RX_MASK: u8 = 0x01;
+
+static mut RX_BUFFER: [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
+static mut RX_HEAD: usize = 0;
+static mut RX_TAIL: usize = 0;
+
+static mut RECEIVED_BREAK: bool = false;
+
+#[derive(PartialEq, Debug)]
+pub enum SDIPinState {
+    Sdi12Sleep,            // SDI-12 slave is sleeping, pin mode INPUT, interrupts enabled for the pin
+    Sdi12Enabled,          // SDI-12 is enabled, pin mode INPUT, interrupts disabled for the pin 
+    Sdi12Holding,          // The line is being held LOW, pin mode OUTPUT, interrupts disabled for the pin
+    Sdi12Transmitting,     // Data is being transmitted by the SDI-12 master, pin mode OUTPUT, interrupts disabled for the pin
+    Sdi12Listening         // The SDI-12 master is listening for a response from the slave, pin mode INPUT, interrupts enabled for the pin
 }
 
-pub trait delay_us {
-    pub fn delay(ms: u32);
+pub trait BoardForSDI12 {
+    fn write(&mut self, value: bool);
+    fn read(&mut self) -> bool;
+    fn delay_us(&mut self, us: u16);
+    fn pin_mode(&mut self, mode: gpio::GpioMode);
+    fn millis(&mut self) -> u32;
+    fn enable_interrupt(&mut self);
+    fn disable_interrupt(&mut self);
+    fn get_current_time(&self) -> u32;  // microseconds
 }
 
+#[allow(non_camel_case_types)]
+pub struct SDI12_MResponse {
+    pub address: char,
+    pub ttt: u32,
+    pub n: u8
+}
 
-pub fn send_command(&str, &mut impl digital_pin, &mut impl delay_us) -> [u8;100] {
-    // sdi-12 implementation
+#[allow(non_camel_case_types)]
+pub struct SDI12_Dresponse {
+    pub address: char,
+    pub data: [f32; 9],
+    pub count: u8,
+    pub terminate: bool,
+    pub last_d_ind: u8
+}
+
+pub struct SDI12 <B> {
+    state: SDIPinState,
+    sdi12_board: B,
+    timeout_counter: u32
+}
+
+impl<B> SDI12<B> where B: BoardForSDI12,
+{
+    pub fn new(sdi12_board: B) -> Self
+    {
+        SDI12 {
+            state: SDIPinState::Sdi12Enabled,
+            sdi12_board: sdi12_board,
+            timeout_counter: 0
+        }
+    }
+
+    pub fn set_state(&mut self, state: SDIPinState) {
+        // set the digital pin to the specified value
+        self.state = state;
+        match self.state {
+            SDIPinState::Sdi12Transmitting => {
+                // set pin mode to OUTPUT
+                self.sdi12_board.pin_mode(gpio::GpioMode::PushPullOutput);
+                self.sdi12_board.disable_interrupt();
+            },
+            SDIPinState::Sdi12Listening => {
+                // set pin mode to INPUT
+                self.sdi12_board.pin_mode(gpio::GpioMode::PullDownInput);        
+                unsafe { 
+                    RX_STATE = WAITING_FOR_START_BIT;     // reset the interrupt state variables
+                    LAST_TICK = self.sdi12_board.get_current_time();
+                }
+                self.sdi12_board.enable_interrupt();
+                defmt::println!("State changed to: Sdi12Listening");      
+            }
+            SDIPinState::Sdi12Sleep => {
+                self.sdi12_board.pin_mode(gpio::GpioMode::PullDownInput);
+                unsafe { 
+                    RX_STATE = WAITING_FOR_BREAK;     // reset the interrupt state variables
+                    RECEIVED_BREAK = false;
+                    LAST_TICK = self.sdi12_board.get_current_time();
+                }  
+                self.sdi12_board.enable_interrupt();
+                defmt::println!("State changed to: Sdi12Sleep");
+            }
+            _ => {
+                // For SDI12_HOLDING and SDI12_ENABLED, set pin mode to INPUT
+                self.sdi12_board.pin_mode(gpio::GpioMode::PullDownInput);
+                self.sdi12_board.disable_interrupt();
+            }
+        }
+    }
+
+    pub fn send_break(&mut self) {
+
+        self.set_state(SDIPinState::Sdi12Transmitting);
+        
+        // Hold it HIGH for 12 ms
+        self.sdi12_board.write(true);
+        self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US);
+        
+        // Marking by holding it LOW for 8.33 ms
+        self.sdi12_board.write(false);
+        self.sdi12_board.delay_us(SDI12_MARK_DURATION_US);
+    }
+
+    pub fn receive_break(&mut self) -> bool {   
+        self.set_state(SDIPinState::Sdi12Listening);
+        if self.sdi12_board.read() {
+            // defmt::println!("Start for 12ms");
+            self.sdi12_board.delay_us(SDI12_BREAK_DURATION_US - SDI12_TIMING_TOLERANCE);
+            let mut iter_count = 0;
+            while self.sdi12_board.read() {
+                // defmt::println!("iter_count: {}", iter_count);
+                if iter_count > 10 {
+                    defmt::println!("Timeout! line is not falling low");
+                    return false;
+                }
+                iter_count += 1;
+                self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
+            }
+            self.sdi12_board.delay_us(SDI12_MARK_DURATION_US - 2 * SDI12_TIMING_TOLERANCE);
+            if self.sdi12_board.read() {
+                defmt::println!("Invalid marking");
+                return false;
+            }
+            self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
+            self.sdi12_board.delay_us(SDI12_TIMING_TOLERANCE);
+            return true;
+        }
+        return false;
+    }
+
+    // pub fn write_char(&mut self, c: char) {
+    //     // sdi-12 write character implementation
+    //     // convert char to byte and write it bit by bit, LSB first, with a start bit and a stop bit
+    //     let mut byte = c as u8;
+    //     let parity = parity_bit(byte);
+    //     byte |= (parity as u8) << 7;    // add parity bit as the most significant bit
+
+    //     // start bit
+    //     self.sdi12_board.write(true);
+    //     self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+    //     // data bits
+    //     for i in 0..8 {
+    //         let bit = (byte >> i) & 1;
+    //         self.sdi12_board.write(bit == 0);
+    //         self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+    //     }
+    //     // stop bit
+    //     self.sdi12_board.write(false);
+    //     self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+    // }
+
+    pub fn write_char(&mut self, c: char) {
+        let mut out_char = c as u8;
+        let ticks_per_bit: u32 = SDI12_TICKS_PER_BIT as u32; // SDI12_TICKS_PER_BIT
+        
+        let mut start_time = self.sdi12_board.get_current_time();
+
+        // 1. Immediately get going on the start bit (HIGH)
+        self.sdi12_board.write(true); 
+
+        // 2. Calculate parity while the start bit is physically holding the line
+        let parity_bit = (out_char.count_ones() as u8) & 1; 
+        out_char |= parity_bit << 7; 
+
+        // 3. Calculate the position of the last bit that is a 0/HIGH.
+        let mut last_high_bit: u8 = 9;
+        let mut msb_mask: u8 = 0x80;
+        
+        while (msb_mask & out_char) != 0 {
+            last_high_bit -= 1;
+            msb_mask >>= 1;
+        }
+
+        // 4. Hold the line for the rest of the start bit duration
+        while self.sdi12_board.get_current_time().wrapping_sub(start_time) < ticks_per_bit {}
+        start_time = start_time.wrapping_add(ticks_per_bit); 
+
+        // 5. Send data bits until the last bit different from marking (LOW)
+        let mut current_tx_bit_num: u8 = 1;
+        
+        while current_tx_bit_num < last_high_bit {
+            let bit_value = out_char & 0x01;
+            
+            if bit_value != 0 {
+                self.sdi12_board.write(false); // LOW for 1's
+            } else {
+                self.sdi12_board.write(true);  // HIGH for 0's
+            }
+
+            // Wait for bit duration
+            while self.sdi12_board.get_current_time().wrapping_sub(start_time) < ticks_per_bit {}
+            start_time = start_time.wrapping_add(ticks_per_bit);
+
+            out_char >>= 1; 
+            current_tx_bit_num += 1;
+        }
+
+        // 6. Set the line LOW for the remaining 1's AND the stop bit
+        self.sdi12_board.write(false);
+
+        // =========================================================
+        // ARCHITECTURE NOTE: 
+        // In the C++ version, interrupts were turned back on right here.
+        // Since your caller manages interrupts, the CPU will remain 
+        // "deaf" to interrupts during this final sleep block as well. 
+        // =========================================================
+
+        // 7. Hold the line LOW until the end of the 10th bit
+        let remaining_bits = 10 - last_high_bit;
+        let bit_time_remaining = ticks_per_bit * (remaining_bits as u32);
+        
+        // Notice we use `start_time` here, so the trailing bits stay locked to the grid
+        while self.sdi12_board.get_current_time().wrapping_sub(start_time) < bit_time_remaining {}
+    }
+
+    pub fn read_char(&mut self) -> Option<char> {
+        let mut iter_count = 0;
+        while self.sdi12_board.read() == false {
+            // let millis = self.sdi12_board.millis();
+            // let elapsed: i32 = millis as i32 - self.timeout_counter as i32;
+            // let mut new_elapsed: u32 = elapsed as u32;
+            // if elapsed < 0 {
+            //     new_elapsed = 65535 - self.timeout_counter + millis;
+            // }
+            // defmt::println!("millis {}, elapsed time: {}, timeout: {}", millis, new_elapsed, self.timeout_counter);
+            // if new_elapsed as u32 > SDI12_TIMEOUT {
+            //     return None; // SDI12_timeout
+            // }
+            if iter_count > 100 {
+                return None;
+            }
+            iter_count += 1;
+            self.sdi12_board.delay_us(1000);
+        }
+        // defmt::println!("detected a start bit");
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT / 2);
+
+        if self.sdi12_board.read() == false {
+            return None; 
+        }
+
+        let mut byte: u8 = 0;
+
+        for i in 0..8 {
+            self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+            let bit_value = match self.sdi12_board.read() {
+                true => 0,
+                false => 1
+            };
+            byte |= bit_value << i;
+        }
+
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+        let stop_bit = self.sdi12_board.read();
+
+        if stop_bit {
+            return None;
+        }
+
+        let character_data = byte & 0x7F;
+
+        // Verify the parity bit here before returning)
+        let parity_bit_received = (byte >> 7) & 1 == 1;
+        let parity_bit_calculated = parity_bit(character_data);
+        if parity_bit_received != parity_bit_calculated {
+            return None;
+        }
+
+        Some(character_data as char)
+    }
+
+    pub fn send_command(&mut self, command: [char; SDI12_COMMAND_SIZE]) {
+        // sdi-12 implementation
+        self.set_state(SDIPinState::Sdi12Transmitting);
+        self.sdi12_board.delay_us(SDI12_GAP);
+        for c in command.iter() {
+            self.write_char(*c);
+            if *c == '!' {
+                break; // stop at termination character
+            }
+            // self.sdi12_board.delay_us(SDI12_GAP);
+        }
+        self.sdi12_board.delay_us(SDI12_TICKS_PER_BIT);
+        defmt::println!("Command sent, switching to listening mode");
+        self.set_state(SDIPinState::Sdi12Listening);
+    }
+
+    pub fn read_command(&mut self) -> [char; SDI12_COMMAND_SIZE] {
+        self.set_state(SDIPinState::Sdi12Listening);
+        let mut buffer: [char; SDI12_COMMAND_SIZE] = ['\0'; SDI12_COMMAND_SIZE];
+        let mut bytes_read = 0;
+
+        while bytes_read < SDI12_COMMAND_SIZE {
+            self.timeout_counter = self.sdi12_board.millis();
+            match self.read_char() {
+                Some(byte) => {
+                    // store the byte in the response buffer
+                    buffer[bytes_read] = byte;
+                    bytes_read += 1;
+                    if byte == '!' {
+                        defmt::println!("buffer[{}] = {}", bytes_read, byte);
+                        break;
+                    }
+                },
+                None => {
+                    defmt::println!("Timeout error");
+                    defmt::println!("buffer[{}] = {}", bytes_read, buffer);
+                    break; // SDI12_timeout or error
+                }
+            }
+        }
+        self.sdi12_board.delay_us(SDI12_GAP);
+
+        buffer
+    }
+
+    pub fn send_response(&mut self, data: [char; SDI12_BUFFER_SIZE]) {
+        self.set_state(SDIPinState::Sdi12Transmitting);
+        self.sdi12_board.delay_us(SDI12_GAP);
+        for c in data.iter() {
+            self.write_char(*c);
+            if *c == '\n' {
+                break; // stop at termination character
+            }
+            // self.sdi12_board.delay_us(SDI12_GAP);
+        }
+        // self.set_state(SDIPinState::Sdi12Listening);
+    }
+
+    pub fn read_response(&mut self) -> [char; SDI12_BUFFER_SIZE] {
+        // sdi-12 implementation
+        self.set_state(SDIPinState::Sdi12Listening);
+        defmt::println!("Reading response...");
+        let mut buffer: [char; SDI12_BUFFER_SIZE] = ['\0'; SDI12_BUFFER_SIZE];
+        let mut bytes_read = 0;
+        while bytes_read < SDI12_BUFFER_SIZE {
+            self.timeout_counter = self.sdi12_board.millis();
+            match self.read_char() {
+                Some(byte) => {
+                    // store the byte in the response buffer
+                    buffer[bytes_read] = byte;
+                    bytes_read += 1;
+                    // defmt::println!("buffer[{}] = {}", bytes_read, byte);
+                    if byte == '\n' {
+                        break;
+                    }
+                },
+                None => {
+                    defmt::println!("Timeout SDI12");
+                    break; // SDI12_timeout or error
+                }
+            }
+        }
+        self.sdi12_board.delay_us(SDI12_GAP);
+        buffer
+    }
+
+    pub fn parse_data(&mut self, response: &[char]) -> ([f32; 9], u8) {
+        let mut count = 0;
+        let mut temp_buf = [0u8; 16]; 
+        let mut temp_len = 0;
+
+        let mut data: [f32; 9] = [0_f32; 9];
+
+        for &c in response {
+            if c == '+' || c == '-' || c == '\r' || c == '\n' {
+                if temp_len > 0 {
+                    // Convert to a string slice
+                    if let Ok(s) = core::str::from_utf8(&temp_buf[..temp_len]) {
+                        // Parse the float
+                        if let Ok(val) = s.parse::<f32>() {
+                            data[count] = val;
+                            count += 1;
+                        }
+                    }
+                }
+                temp_len = 0;
+                if c == '\r' || c == '\n' {
+                    break;
+                }
+                
+                if c == '+' || c == '-' {
+                    temp_buf[0] = c as u8;
+                    temp_len = 1;
+                }
+                
+            } 
+            else if c.is_ascii() && temp_len < temp_buf.len() {
+                temp_buf[temp_len] = c as u8;
+                temp_len += 1;
+            }
+        }
+
+        (data, count as u8)
+    }
+
+    pub fn available(&mut self) -> usize {
+        unsafe {
+            (RX_TAIL + SDI12_BUFFER_SIZE - RX_HEAD) % SDI12_BUFFER_SIZE
+        }
+    }
+
+    pub fn read(&mut self) -> Option<char> {
+        unsafe {
+            if RX_HEAD == RX_TAIL {
+                None
+            }
+            else {
+                let c = RX_BUFFER[RX_HEAD];
+                RX_HEAD = (RX_HEAD + 1) % SDI12_BUFFER_SIZE;
+                Some(c)
+            }
+        }
+    }
+
+    pub fn peek(&mut self) -> Option<char> {
+        unsafe {
+            if RX_HEAD == RX_TAIL {
+                None
+            }
+            else {
+                Some(RX_BUFFER[RX_HEAD])
+            }
+        }
+    }
+
+    pub fn clear_buffer(&mut self) {
+        unsafe {
+            RX_HEAD = 0;
+            RX_TAIL = 0;
+        }
+    }
+
+    pub fn sleep(&mut self) {
+        self.set_state(SDIPinState::Sdi12Sleep);
+    }
+
+    pub fn awake(&mut self) -> bool {
+        let received_break = unsafe { RECEIVED_BREAK };
+        received_break
+    }
+}
+
+// Helper functions
+fn parity_bit(byte: u8) -> bool {
+    // returns the parity bit for the given byte, true for odd parity, false for even parity
+    let mut count = 0;
+    for i in 0..8 {
+        if (byte >> i) & 1 == 1 {
+            count += 1;
+        }
+    }
+    count % 2 == 1
+}
+
+fn num_bits_passed(dt: u32) -> u16 {
+    ((dt + 2) / SDI12_TICKS_PER_BIT as u32) as u16
+}
+
+// Interrupt Handlers
+fn start_char() {
+    unsafe {
+        RX_STATE = 0;
+        RX_VALUE = 0x00;
+        RX_MASK = 0x01;
+    }
+}
+
+fn char_to_buffer(c: char) {
+    unsafe {
+        if (RX_TAIL + 1) % SDI12_BUFFER_SIZE == RX_HEAD {
+            defmt::println!("Buffer overflow, discarding data");
+        }
+        else {
+            RX_BUFFER[RX_TAIL] = c;
+            RX_TAIL = (RX_TAIL + 1) % SDI12_BUFFER_SIZE;
+        }
+    }
+}
+
+pub fn datalogger_interrupt_handler(now: u32, gpio_state: bool) {
+
+    let dt = now.wrapping_sub(unsafe { LAST_TICK });
+    let bits_passed = num_bits_passed(dt);
+    unsafe { LAST_TICK = now; }
+    let mut rx_state = unsafe { RX_STATE };
+    let mut rx_value = unsafe { RX_VALUE };
+    let mut rx_mask = unsafe { RX_MASK };
+
+    // defmt::println!("Interrupt! gpio_state: {}, dt: {}, bits_passed: {}, rx_state: {}", gpio_state, dt, bits_passed, rx_state);
+
+    // Waiting for start bit
+    if rx_state == WAITING_FOR_START_BIT {
+        if gpio_state == true {
+            // it is a start bit
+            start_char();
+        }
+        return;
+    }
+    else {
+        // Receiving bits for a byte
+        let bits_left = 9 - rx_state;
+
+        let next_char_started = bits_passed > bits_left as u16;
+        let mut bits_to_process = if next_char_started { bits_left } else { bits_passed as u8 };
+        rx_state += bits_to_process;
+
+        if gpio_state == true {
+            while bits_to_process > 0 {
+                rx_value |= rx_mask;      // all the LOW bits are stored as 1
+                rx_mask <<= 1;
+                bits_to_process -= 1;
+            }
+            rx_mask <<= 1;   // for the current bit which is HIGH is stored as 0
+        }
+        else {
+            rx_mask <<= bits_to_process - 1;   // if the bit is LOW, just move the mask
+            rx_value |= rx_mask;  // store the LOW bit as 1
+        }
+
+        if rx_state > 7 {
+            // check parity bit
+            // let parity_bit_received = (rx_value >> 7) & 1 == 0;
+            // let parity_bit_calculated = parity_bit(rx_value & 0x7F);
+            // if parity_bit_received == parity_bit_calculated {
+            //     char_to_buffer((rx_value & 0x7F) as char);
+            // }
+            // else {
+            //     defmt::println!("Parity error, discarding byte");
+            //     start_char();
+            //     return;
+            // }
+            char_to_buffer((rx_value & 0x7F) as char);
+
+            if gpio_state == false || !next_char_started {
+                rx_state = WAITING_FOR_START_BIT;
+            }
+            else {
+                start_char();
+                return;
+            }
+        }
+    }
+    unsafe {
+        RX_STATE = rx_state;
+        RX_VALUE = rx_value;
+        RX_MASK = rx_mask;
+    }
+}
+
+pub fn probe_interrupt_handler(now: u32, gpio_state: bool) {
+
+    let dt = now.wrapping_sub(unsafe { LAST_TICK });
+    let bits_passed = num_bits_passed(dt);
+    let mut rx_state = unsafe { RX_STATE };
+    let mut rx_value = unsafe { RX_VALUE };
+    let mut rx_mask = unsafe { RX_MASK };
+    // defmt::println!("Interrupt! gpio_state: {}, LAST_TICK: {}, dt: {}, bits_passed: {}, rx_state: {}", gpio_state, unsafe { LAST_TICK }, dt, bits_passed, rx_state);
+    unsafe { LAST_TICK = now; }
+
+    match rx_state {
+        WAITING_FOR_BREAK => {
+            if gpio_state == true {
+                defmt::println!("Break started!");
+                rx_state = WAITING_FOR_MARK;
+            }
+        }
+        WAITING_FOR_MARK => {
+            if gpio_state == false {
+                if dt > (SDI12_MARK_DURATION_US - SDI12_TIMING_TOLERANCE) as u32 {
+                    defmt::println!("Valid marking condition detected, ready to receive data");
+                    rx_state = WAITING_FOR_START_AFTER_BREAK;
+                }
+                else {
+                    defmt::println!("Invalid marking condition, waiting for break again");
+                    rx_state = WAITING_FOR_BREAK;
+                }
+            }
+            else {
+                rx_state = WAITING_FOR_BREAK;
+            }
+        }
+        WAITING_FOR_START_AFTER_BREAK => {
+            if gpio_state == true {
+                // it is a start bit after valid marking condition
+                if dt > (SDI12_MARK_DURATION_US - SDI12_TIMING_TOLERANCE) as u32 {
+                    unsafe { RECEIVED_BREAK = true; }
+                    start_char();
+                    return;
+                }
+                else {
+                    defmt::println!("Invalid marking condition, waiting for break again");
+                    rx_state = WAITING_FOR_BREAK;
+                }
+            }
+            else {
+                rx_state = WAITING_FOR_BREAK;
+            }
+        }
+        WAITING_FOR_START_BIT => {
+            if gpio_state == true {
+                // it is a start bit
+                start_char();
+                return;
+            }
+        }
+        _ => {
+            // Receiving bits for a byte
+            let bits_left = 9 - rx_state;
+            let next_char_started = bits_passed > bits_left as u16;
+            let mut bits_to_process = if next_char_started { bits_left } else { bits_passed as u8 };
+            rx_state += bits_to_process;
+
+            if gpio_state == true {
+                while bits_to_process > 0 {
+                    rx_value |= rx_mask;      // all the LOW bits are stored as 1
+                    rx_mask <<= 1;
+                    bits_to_process -= 1;
+                }
+                rx_mask <<= 1;   // for the current bit which is HIGH is stored as 0
+            }
+            else {
+                rx_mask <<= bits_to_process - 1;   // if the bit is LOW, just move the mask
+                rx_value |= rx_mask;  // store the LOW bit as 1
+            }
+
+            if rx_state > 7 {
+                // check parity bit
+                // let parity_bit_received = (rx_value >> 7) & 1 == 0;
+                // let parity_bit_calculated = parity_bit(rx_value & 0x7F);
+                // if parity_bit_received == parity_bit_calculated {
+                //     char_to_buffer((rx_value & 0x7F) as char);
+                // }
+                // else {
+                //     defmt::println!("Parity error, discarding byte");
+                //     start_char();
+                //     return;
+                // }
+                char_to_buffer((rx_value & 0x7F) as char);
+                if gpio_state == false || !next_char_started {
+                    rx_state = WAITING_FOR_START_BIT;
+                }
+                else {
+                    start_char();
+                    return;
+                }
+            }
+        }
+    }
+
+    unsafe {
+        RX_STATE = rx_state;
+        RX_VALUE = rx_value;
+        RX_MASK = rx_mask;
+    }
 }

--- a/src/util/src/lib.rs
+++ b/src/util/src/lib.rs
@@ -49,7 +49,7 @@ pub fn format_error<'a>(error: &'a dyn Debug, buffer: &'a mut [u8]) -> &'a str {
     }
 }
 
-pub fn format_decimal(value: u32) -> Result<([u8;20], usize), ()> {
+pub fn format_decimal(value: i32) -> Result<([u8;20], usize), ()> {
     let format_int = format_args!("{}", value );
 
     let mut buf: [u8; _] = [0u8; 20];


### PR DESCRIPTION
- **feat: allow selection of output parameters in ring mux driver**
- **feat: move the watchdog earlier**
- **fix: move the enable 3v so we dont crash stuff**
- **chore: remove unnecessary flags from attach script**
- **fix: remove some rprint**
- **chore: run build check on new commit push to pr**
- **fix: remove some rprint**
- **fix: remove some rprint**
- **fix: remove unused column headers code**
- **fix: remove unnecessary gpio6 hard coded setup**
- **fix: used TIM5 for millis counter**
- **fix: keep clocks object around for later use**
- **fix: properly unwrap the gpio object**
- **feat: define properties and functions for pwm**
- **feat: implement the pwm pin**
- **fix: Comment out the incomplete uart5 serial for now**
- **fix: move pwm setup earlier to address hard fault**
- **fix: disable pin 1 normal operation**
- **fix: missing comma**
- **fix: imports**
- **fix: use PushPull mode**
- **fix: initialize pwm**
- **feat: apply pwm in timed_switch**
- **feat: added pwm_set_period fn**
- **fix: comment old pwm code**
- **feat: applied period fn in timed switch**
- **feat: made sw pwm as additonal configuration**
- **fix: initial_state code is enabled**
- **fix: added pwm_type in update_from_values fn**
- **wip: futher details and pwm not initing**
- **wip: try moving steal around**
- **fix: correct order of pin stealing**
- **fix: calcuate hardware pwm bool as separate variable**
- **fix: for some reason need to reference boolean to get it to evaluate in if statement**
- **fix: remove extra output**
- **fix: Update ring_w_mux.rs addresses**
- **fix: Update ring_w_mux.rs final addres fix**
- **wip: sdi12 skeleton**
- **fix: cargo setup for sdi12**
- **feat: added delay_us fn in rriv board**
- **feat: sdi-12 services**
- **fix: use the true parameter count**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.1 [skip ci]**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.2 [skip ci]**
- **fix: uid in usb identity**
- **feat: implement mode locking**
- **fix: watch and driver fixes**
- **fix: commented usb serial send**
- **fix: remove spamming dfmt message**
- **fix: rendering order of digits**
- **fix: clear data received each time we query**
- **fix: handle hung SDI12, timeout and restart command mode**
- **fix: get rid of rtt**
- **fix: shorten var names so we dont use up the buffer**
- **fix: rename pwm_type to hardware_pwm for clarity**
- **fix: handle garbled out of range data requests without crashing**
- **fix: send a decimal thats only 2 long and format it correctly**
- **fix: remove dead code**
- **fix: add watch mode data for sdi12**
- **fix: go back to sdi12 sleep after timeout**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.3 [skip ci]**
- **fix: increase buffer size for longer rrivctl payloads**
- **fix: allow sensor update payloads without sensor type key**
- **fix: correct id for ring mux**
- **fix: remove that white space**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.4 [skip ci]**
- **fix: increase size of command buffer**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.5 [skip ci]**
- **fix: increase size sdi12 values buffer**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.6 [skip ci]**
- **fix: error out if we end up without any more bits**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.7 [skip ci]**
- **attempt at pwm fix**
- **fix:attempt at pwm fix**
- **fix: attempt at pwm fix**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.8 [skip ci]**
- **fix: remove software gpio from hardware pwm**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.9 [skip ci]**
- **fix: refactor how hardware pwm is applied to resolve sequencing problems**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.10 [skip ci]**
- **fix: also apply hardware pwm in setup**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.11 [skip ci]**
- **fix: add a little delay on timeout**
- **fix: dont defmt print the serialrx bytes**
- **fix: add some led indications**
- **fix: dont need empty space in structs anymore**
- **fix: improve logic for hardware pwm on/off**
- **chore: add todos**
- **fix: improve debug message**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.12 [skip ci]**
- **fix: hard code hardware pwm mode**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.13 [skip ci]**
- **wip: improve notification led**
- **fix: add some improved notification led behavior for boot**
- **fix: add some improved notification led behavior for boot**
- **fix: correct size of bytes in the special config struct**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.14 [skip ci]**
- **feat: move the watchdog earlier**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.15 [skip ci]**
- **fix: improve handling of disable-storage feature**
- **chore(release): 1.14.0-preview-sdi12-pwm-groundwater.16 [skip ci]**
- **fix: stop using NaiveDate**
- **fix: some warnings**
